### PR TITLE
support UTF encoding for jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,5 @@ current_version: 1.1.1
 
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript", "with_toc_data", "tables"]
+
+encoding: utf-8


### PR DESCRIPTION
@johnwunder @gtback 
This fixes an issue where jekyll 1.5.1 would not build the source docs locally due to the use of fancy >> characters in some source files.

i.e. `bundle exec jekyll build` =>
`Error reading file /home/dstar/Applications/stixproject.github.io/data-model/1.0.1/index.md: "\xE2" on US-ASCII`

Likely a non-blocking change, since it builds on github fine either way.
