### PR TITLE
CybOX object expressiveness 42101

### DIFF
--- a/documentation/suggested-practices/index.md
+++ b/documentation/suggested-practices/index.md
@@ -137,7 +137,7 @@ References to non-versioned constructs (anything with an id/idref but not a time
 
 ## CybOX Object selection
 
-Suggested practices for [CybOX Object selection](https://cyboxproject.github.io/documentation/suggested-practices/cybox-object-selection)
+Suggested practices for [CybOX Object selection](https://cyboxproject.github.io/documentation/suggested-practices/#cybox-object-selection)
 
 
 ## Creating documents for human consumption


### PR DESCRIPTION
This should be a pretty clean pull.
CybOX-related content was moved from the STIX suggested practices to the CybOX suggested practices and replaced with a link to the CybOX site content
