### PR TITLE
Added TOC to suggested practices

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<div id="footer">
+<div id="footer" {% if page.toc %}style="position: relative;"{% endif %}>
   <hr />
   <div class="container">
     <p class="text-muted">

--- a/_includes/sp_toc.html
+++ b/_includes/sp_toc.html
@@ -1,0 +1,17 @@
+<ul class="nav">
+  <li class="header">General Practices</li>
+  <li><a href="#formatting-ids">Formatting IDs</a></li>
+  <li><a href="#assigning-ids">Assigning IDs</a></li>
+  <li><a href="#titles-and-descriptions">Titles &amp; Descriptions</a></li>
+  <li><a href="#information-source">Information Source</a></li>
+  <li><a href="#referencing-vs-embedding">Referencing vs. Embedding</a></li>
+  <li><a href="#versioning">Versioning</a></li>
+  <li><a href="#using-vocabularies">Using Vocabularies</a></li>
+  <li><a href="#creating-timestamps">Creating Timestamps</a></li>
+  <li><a href="#creating-documents-for-human-consumption">Human Readability</a></li>
+  <li class="header">Construct Practices</li>
+  <li><a href="#stix-package">STIXType (STIX_Package)</a></li>
+  <li><a href="#indicator">Indicator</a></li>
+  <li><a href="#observable">Observable</a></li>
+  <li><a href="#handling">Data Markings</a></li>
+</ul>

--- a/_layouts/flat.html
+++ b/_layouts/flat.html
@@ -1,13 +1,25 @@
 <!DOCTYPE html>
 <html>
   {% include header.html %}
-  <body>
+  <body{% if page.toc %} data-spy="scroll" data-target="#toc" style="position: relative; margin-bottom: 0;"{% endif %}>
 
     {% include nav.html %}
 
     <div class="container">
-      {% unless page.no_in_page_title %}<h1>{{ page.title }}</h1>{% endunless %}
-      {{ content }}
+      {% if page.toc %}
+        <div class="col-md-10">
+          {% unless page.no_in_page_title %}<h1>{{ page.title }}</h1>{% endunless %}
+          {{ content }}
+        </div>
+        <div class="col-md-2">
+          <div id="toc" class="well pull-right hidden-sm affix">
+            {% include {{page.toc}} %}
+          </div>
+        </div>
+      {% else %}
+        {% unless page.no_in_page_title %}<h1>{{ page.title }}</h1>{% endunless %}
+        {{ content }}
+      {% endif %}
     </div>
 
     {% include footer.html %}

--- a/css/main.css
+++ b/css/main.css
@@ -251,3 +251,35 @@ p.data-model-description {
 .tab-pane.active > img {
   margin: 15px;
 }
+
+#toc li.header {
+  font-size: 16px;
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+#toc .nav>li>a {
+  padding: 0;
+}
+
+#toc .nav>li.active>a {
+  border-left: 2px solid #aaa;
+  position: relative;
+  padding-left: 5px;
+  left: -7px;
+}
+
+
+#toc li.header:first-child {
+  margin-top: 0;
+}
+
+#toc ul {
+  padding-left: 5px;
+  
+}
+
+#toc li {
+  list-style-type: none;
+  font-size: 12px;
+}

--- a/documentation/suggested-practices/index.md
+++ b/documentation/suggested-practices/index.md
@@ -1,6 +1,7 @@
 ---
 layout: flat
 title: Suggested Practices
+toc: sp_toc.html
 ---
 
 This page contains suggested practices (sometimes called best practices) for producing and consuming STIX content. Following these practices will ensure the best conformance with the design goals of STIX and the best compatibility with other STIX tools. These are not requirements, however: in some cases, technical or business requirements will mean you can't comply with them and that's fine. Think of them as "do it this way unless you have a good reason not to".
@@ -66,7 +67,7 @@ For these reasons, it is suggested that IDs be specified for the following commo
 As a simple general rule specifying IDs is not suggested for constructs embedded within other constructs (e.g. a CybOX Object containing the embedded specification of another CybOX Related_Object) where the embedded constructs are really only relevant/valid/important within the context of the enclosing construct. In other words they provide contextual characterization for the enclosing construct but would not be of interest on their own. 
 The upside of this is slightly less complexity of IDs on everything. The downside is that it would not be possible to reference or pivot on the embedded constructs.
 
-### Title, Description, and Short_Description
+### Titles and Descriptions
 
 The top-level STIX components as well as other important constructs ([VulnerabilityType](/data-model/{{site.current_version}}/et/VulnerabilityType/), for example) each have fields for Title, Description, and Short_Description:
 
@@ -101,7 +102,7 @@ For the purposes of Information Source override means "completely replaces".
 
 Note that on [Indicator](/data-model/{{site.current_version}}/indicator/IndicatorType/) the information source field is called `Producer`. On [Observable](/data-model/{{site.current_version}}/cybox/ObservableType/), it's called `Observable_Source` and uses the semantics and structure of the CybOX [MeasureSourceType](/data-model/{{site.current_version}}/cyboxCommon/MeasureSourceType/).
 
-### Referencing vs. Embedding
+### Referencing vs Embedding
 
 In many cases, you'll have an option to either include a component within the parent component or to reference the component by ID to a representation in a global location.
 
@@ -131,7 +132,7 @@ The other alternative is to reference that TTP, which would be represented elsew
 
 These situations are a judgment call, but when making that judgment you should consider whether the related construct has value individually or only within the context of the parent? If it only has value in the parent, embedding it may be appropriate. Otherwise it's probably better to reference it. If you're unsure, it's generally safer to reference it.
 
-### Versioning and the timestamp attribute
+### Versioning
 
 8 major STIX constructs are versioned:
 


### PR DESCRIPTION
This PR adds the ability to support tables of contents on specific pages and adds one to suggested practices.

The `toc` parameter is used to identify where the TOC for that page is stored. The TOC itself must be maintained manually. Various other style/markup changes in `flat.html` make the layout work with bootstrap scrollspy (i.e. see where you are in TOC).
