### PR TITLE
add /community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -13,7 +13,7 @@ title: STIX Community
 * [Key Resources & Contacts](https://stixproject.github.io/oasis-cti-info.html)
 
 ##Discussion List & Archive
-Please join us by signing up for our email discussion list and e-newsletter. [Privacy Policy](https://stix.mitre.org/about/privacy_policy.html)
+Please join us by signing up for our email discussion list and e-newsletter. [Privacy Policy](https://stix.mitre.org/about/privacy_policy.html).
 
 * [STIX Community Email Discussion List sign-up](http://stix.mitre.org/community/registration.html)
 * [STIX Announce e-Newsletter sign-up](http://stix.mitre.org/community/registration.html)

--- a/community/index.md
+++ b/community/index.md
@@ -1,0 +1,31 @@
+---
+layout: flat
+title: STIX Community
+---
+
+
+##OASIS Transition
+[DHS](http://www.dhs.gov/office-cybersecurity-and-communications/) is transitioning STIX, [TAXII](https://github.com/TAXIIProject/), and [CybOX](https://github.com/CybOXProject/) to [Organization for the Advancement of Structured Information Standards (OASIS)](https://www.oasis-open.org/), a non-profit consortium that drives the development, convergence, and adoption of open standards for the global information society, in May 2015. Learn more:
+
+* [Announcement](http://stixproject.tumblr.com/post/117006597637/dhs-leads-effort-to-transition-automated)
+* [FAQ](https://stixproject.github.io/oasis-faq.pdf)
+* [OASIS Overview](https://stixproject.github.io/stix-at-oasis.pdf)
+* [Key Resources & Contacts](https://stixproject.github.io/oasis-cti-info.html)
+
+##Discussion List & Archive
+Please join us by signing up for our email discussion list and e-newsletter. [Privacy Policy](https://stix.mitre.org/about/privacy_policy.html)
+
+* [STIX Community Email Discussion List sign-up](http://stix.mitre.org/community/registration.html)
+* [STIX Announce e-Newsletter sign-up](http://stix.mitre.org/community/registration.html)
+* [Discussion List Archive](http://making-security-measurable.1364806.n2.nabble.com/STIX-Discussion-List-f7579090.html)
+
+**NOTE:** OASIS will host a new STIX Discussion List and Archives once the transition is completed in May 2015. The pre-transition Discussion List Archives will also be retained. 
+
+##STIX Supporters
+A growing [list](http://stixproject.github.io/supporters/) of products, services, and sharing communities using STIX and TAXII.
+
+* [By User Community](http://stixproject.github.io/supporters/#user-communities)
+* [By Product/Service](http://stixproject.github.io/supporters/#products-and-services)
+
+##Contact Us
+* [stix@mitre.org](mailto:stix@mitre.org)


### PR DESCRIPTION
@jonathanbaker, @johnwunder, @sbarnum, @bschmoker

As part of this I recommend adding "Community" as a menu item in the Main Site Navigation to the right of "About". I also recommend "Supporters" be a drop-down item under the new "Community" menu item, so visitors can go directly to that page from the main site nav without having to scroll down the Community page to find it.

Finally, I wasn't sure if the 'OASIS Transition' section of this page should have a time frame mentioned, or just leave it to the announcement & faq? I used May 2015 in two places above so it was in there but not too specific in case the actual dates move at all, but this could be deleted if you prefer.

What do you think?
-Bob