### PR TITLE
Suggested edits to update the Homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,11 +1,11 @@
 ---
 layout: flat
-title: STIX Project Documentation
-tagline: User and developer documentation for STIX
+title: STIX - Structured Threat Information Expression
+tagline: A structured language for cyber threat intelligence information
 no_in_page_title: true
 ---
 
-<h1 class="site-title">STIX Project Documentation</h1>
+<h1 class="site-title">Structured Threat Information eXpression (STIX™)</h1>
 
 <div class="jumbotron">
   <h2><strong>Start here if you're new to STIX!</strong></h2>
@@ -17,6 +17,38 @@ no_in_page_title: true
   </p>
 </div>
 
+<div class="row">
+  <div class="col-md-4 text-center">
+    <h2>STIX Version 1.1.1</h2>
+    <p>The current release of the language. Click for downloads and more.</p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.1.1/">STIX Version 1.1.1 »</a></p>
+  </div>
+  <div class="col-md-4 text-center">
+    <h2>STIX Version 1.2</h2>
+    <p>Upcoming release of the language. Click for status reports and more.</p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.2/">STIX Version 1.2 »</a></p>
+  </div>
+  <div class="col-md-4 text-center">
+    <h2>Follow the STIX Blog</h2>
+    <p>The latest STIX , TAXII, CybOX, & MAEC news, straight from the source.</p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="/blog">Follow »</a></p>
+  </div>
+</div>
+
+<hr />
+
+<p class="lead text-center">
+	Have questions, comments, or feedback?
+	<br/>
+	<strong>Reach out to us at <a href="mailto:stix@mitre.org">stix@mitre.org</a>!</strong>
+</p>
+
+<div class="row">
+  <div class="col-md-4 text-center">
+    <h2>OASIS</h2>
+    <p>STIX, TAXII, and CybOX are being transitioned to the Organization for the Advancement of Structured Information Standards (OASIS)</p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="https://stixproject.github.io/stix-at-oasis.pdf">Announcement »</a></p>
+  </div>
 <div class="row">
   <div class="col-md-4 text-center">
     <h2>Documentation</h2>
@@ -31,45 +63,4 @@ no_in_page_title: true
     learn how to create and understand idiomatic STIX content.</p>
     <p><a class="btn btn-primary btn-lg" role="button" href="/documentation/idioms">Idioms »</a></p>
   </div>
-  <div class="col-md-4 text-center">
-    <h2>Follow the STIX Blog</h2>
-    <p>The latest news, straight from the source.</p>
-    <p><a class="btn btn-primary btn-lg" role="button" href="/blog">Follow »</a></p>
-  </div>
-</div>
 
-<hr />
-
-<p class="lead text-center">
-	Have questions, comments, or feedback? Want to set up a teleconference or in-person meeting?
-	<br/>
-	<strong>Reach out to us at <a href="mailto:stix-taxii@hq.dhs.gov">stix-taxii@hq.dhs.gov</a>!</strong>
-</p>
-
-<div class="row">
-    <div class="col-md-4">
-      <h3 class="text-center">Teleconferences</h3>
-	  <div class="contact-icon">
-		  <span class="glyphicon glyphicon-earphone">
-		  </span>
-	  </div>
-      <p>We're always happy to set up a teleconference to go through an introductory session, a more in-depth training/development session, or to walk you through how to map your existing content into STIX.</p>
-	  <p>Get in touch with us via email to arrange one!</p>
-    </div>
-    <div class="col-md-4">
-      <h3 class="text-center">In-Person Meetings</h3>
-	  <div class="contact-icon">
-		  <span class="glyphicon glyphicon-user">
-		  </span>
-	  </div>
-      <p>Prefer an in-person meeting? We can meet with you in person for any of the purposes we would also cover via teleconference. Send us an email to schedule a meeting.</p>
-    </div>
-    <div class="col-md-4">
-      <h3 class="text-center">Training Sessions</h3>
-	  <div class="contact-icon">
-		  <span class="glyphicon glyphicon-pencil">
-		  </span>
-	  </div>
-	  <p>We host occasional training sessions that are free and open to the public. Information on these can be found on the <a href="http://stix.mitre.org/training/index.html">training</a> page.</p>
-    </div>
-</div>

--- a/index.md
+++ b/index.md
@@ -19,18 +19,18 @@ no_in_page_title: true
 
 <div class="row">
   <div class="col-md-4 text-center">
-    <h2>STIX Version 1.1.1</h2>
-    <p>The current release of the language. Click for downloads and more.</p>
+    <h2>Current Release</h2>
+    <p>Click for STIX Version 1.1.1 downloads and more.</p>
     <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.1.1/">STIX Version 1.1.1 »</a></p>
   </div>
   <div class="col-md-4 text-center">
-    <h2>STIX Version 1.2</h2>
-    <p>Upcoming release of the language. Click for status reports and more.</p>
+    <h2>Community</h2>
+    <p>Join us to help build this growing, open-source industry effort.</p>
     <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.2/">STIX Version 1.2 »</a></p>
   </div>
   <div class="col-md-4 text-center">
     <h2>Follow the STIX Blog</h2>
-    <p>The latest STIX , TAXII, CybOX, & MAEC news, straight from the source.</p>
+    <p>The latest STIX, TAXII, CybOX, & MAEC news, straight from the source.</p>
     <p><a class="btn btn-primary btn-lg" role="button" href="/blog">Follow »</a></p>
   </div>
 </div>

--- a/index.md
+++ b/index.md
@@ -20,13 +20,13 @@ no_in_page_title: true
 <div class="row">
   <div class="col-md-4 text-center">
     <h2>Current Release</h2>
-    <p>Click for STIX Version 1.1.1 downloads and more.</p>
+    <p>Click for downloads and more.</p>
     <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.1.1/">STIX Version 1.1.1 »</a></p>
   </div>
   <div class="col-md-4 text-center">
     <h2>Community</h2>
     <p>Join us to help build this growing, open-source industry effort.</p>
-    <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.2/">STIX Version 1.2 »</a></p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="http://stixproject.github.io/community">Participate »</a></p>
   </div>
   <div class="col-md-4 text-center">
     <h2>Follow the STIX Blog</h2>


### PR DESCRIPTION
@jonathanbaker, @johnwunder, @sbarnum, @bschmoker

Not sure why preview doesn't look like live site, but:
(1) Changed site title to fully spelled-out STIX name, as discussed at the f-2-f.
(2) Removed the 3 training promo items, as discussed at the f-2-f.
(3) Added items for Version 1.2 upcoming release; Version 1.1.1. current release (to be replaced with Community once v1.2 is live); and OASIS, with a link to the Announcement doc since the FAQ is linked above.
(4) Changed the mailto link to 'stix@mitre.org' (at the f-2-f, Rich said he doesn't monitor the other email account).
(5) STILL NEEDED:  addition of the new STIX logo.