### PR TITLE
update examples for 1.2

### DIFF
--- a/documentation/idioms/affected-assets/incident-with-affected-asset.xml
+++ b/documentation/idioms/affected-assets/incident-with-affected-asset.xml
@@ -11,7 +11,6 @@
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" 
 	id="example:Package-d1a8110e-b693-11e3-8747-0800271e87d2" 
-	timestamp="2014-05-08T09:00:00.000000Z"
 	version="1.1.1">
     <stix:Incidents>
         <stix:Incident id="example:incident-081d344b-9fae-d182-9cc7-d2d103e7c64f" xsi:type='incident:IncidentType' timestamp="2014-05-08T09:00:00.000000Z">

--- a/documentation/idioms/c2-indicator/index.md
+++ b/documentation/idioms/c2-indicator/index.md
@@ -28,24 +28,28 @@ In the diagram above, the Indicator component contains the test: a CybOX [Addres
 ## Implementation
 
 {% include start_tabs.html tabs="XML|Python Producer|Python Consumer" name="c2-indicator" %}{% highlight xml linenos %}
-<stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-02-20T09:00:00.000000Z">
-    <indicator:Title>IP Address for known C2 channel</indicator:Title>
-    <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
-    <indicator:Observable  id="example:Observable-1c798262-a4cd-434d-a958-884d6980c459">
-        <cybox:Object id="example:Object-1980ce43-8e03-490b-863a-ea404d12242e">
-            <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
-                <AddressObject:Address_Value condition="Equals">10.0.0.0</AddressObject:Address_Value>
-            </cybox:Properties>
-        </cybox:Object>
-    </indicator:Observable>
-    <indicator:Indicated_TTP>
-        <stixCommon:TTP idref="example:TTP-bc66360d-a7d1-4d8c-ad1a-ea3a13d62da9" />
-    </indicator:Indicated_TTP>
-</stix:Indicator>
-<!-- SNIP -->
-<stix:TTP xsi:type="ttp:TTPType" id="example:TTP-bc66360d-a7d1-4d8c-ad1a-ea3a13d62da9" timestamp="2014-02-20T09:00:00.000000Z">
-    <ttp:Title>C2 Behavior</ttp:Title>
-</stix:TTP>
+<stix:Indicators>
+        <stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
+            <indicator:Title>IP Address for known C2 channel</indicator:Title>
+            <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
+            <indicator:Observable  id="example:Observable-1c798262-a4cd-434d-a958-884d6980c459">
+                <cybox:Object id="example:Object-1980ce43-8e03-490b-863a-ea404d12242e">
+                    <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
+                        <AddressObject:Address_Value condition="Equals">10.0.0.0</AddressObject:Address_Value>
+                    </cybox:Properties>
+                </cybox:Object>
+            </indicator:Observable>
+            <indicator:Indicated_TTP>
+                <stixCommon:TTP idref="example:TTP-bc66360d-a7d1-4d8c-ad1a-ea3a13d62da9" />
+            </indicator:Indicated_TTP>
+        </stix:Indicator>
+    </stix:Indicators>
+    <stix:TTPs>
+        <stix:TTP xsi:type="ttp:TTPType" id="example:TTP-bc66360d-a7d1-4d8c-ad1a-ea3a13d62da9" timestamp="2014-05-08T09:00:00.000000Z">
+            <ttp:Title>C2 Behavior</ttp:Title>
+        </stix:TTP>
+    </stix:TTPs>
+</stix:STIX_Package>
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 stix_package = STIXPackage()
@@ -66,9 +70,6 @@ print stix_package.to_xml()
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 stix_package = STIXPackage.from_xml('indicator-for-c2-ip-address.xml')
-
-print "Title: " + stix_package.stix_header.title,
-
 
 for indicator in stix_package.indicators:
   print "--INDICATOR--"

--- a/documentation/idioms/c2-indicator/indicator-for-c2-ip-address.xml
+++ b/documentation/idioms/c2-indicator/indicator-for-c2-ip-address.xml
@@ -15,13 +15,8 @@
     http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
     http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd"
     id="example:STIXPackage-33fe3b22-0201-47cf-85d0-97c02164528d"
-    timestamp="2014-05-08T09:00:00.000000Z"
     version="1.1.1"
     >
-    <stix:STIX_Header>
-        <stix:Title>Example watchlist that contains IP information.</stix:Title>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
-    </stix:STIX_Header>
     <stix:Indicators>
         <stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
             <indicator:Title>IP Address for known C2 channel</indicator:Title>

--- a/documentation/idioms/c2-indicator/indicator-for-c2-ip-address_consumer.py
+++ b/documentation/idioms/c2-indicator/indicator-for-c2-ip-address_consumer.py
@@ -12,9 +12,6 @@ from stix.core import STIXPackage
 def main():
   stix_package = STIXPackage.from_xml('indicator-for-c2-ip-address.xml')
 
-  print "Title: " + stix_package.stix_header.title,
-
-
   for indicator in stix_package.indicators:
     print "--INDICATOR--"
     ip = indicator.observable.object_.properties.address_value.value

--- a/documentation/idioms/c2-ip-list/command-and-control-ip-list.xml
+++ b/documentation/idioms/c2-ip-list/command-and-control-ip-list.xml
@@ -17,12 +17,8 @@
     http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
     http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd"
     id="example:STIXPackage-cc0ca596-70e6-4dac-9bef-603166d17db8"
-    timestamp="2014-05-08T09:00:00.000000Z"
     version="1.1.1"
     >
-    <stix:STIX_Header>
-        <stix:Title>Example Command and Control IP List</stix:Title>
-    </stix:STIX_Header>
     <stix:Observables cybox_major_version="1" cybox_minor_version="1">
         <cybox:Observable id="example:observable-c8c32b6e-2ea8-51c4-6446-7f5218072f27">
             <cybox:Object id="example:object-d7fcce87-0e98-4537-81bf-1e7ca9ad3734">

--- a/documentation/idioms/campaign-v-actors/campaign-v-actors.xml
+++ b/documentation/idioms/campaign-v-actors/campaign-v-actors.xml
@@ -13,7 +13,7 @@
     http://stix.mitre.org/ThreatActor-1 http://stix.mitre.org/XMLSchema/threat_actor/1.1.1/threat_actor.xsd
     http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
     http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-    http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-81810123-b298-40f6-a4e7-186efcd07670" version="1.1.1" timestamp="2014-08-08T15:50:10.983851+00:00">
+    http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-81810123-b298-40f6-a4e7-186efcd07670" version="1.1.1" >
     <stix:Campaigns>
         <stix:Campaign id="example:Campaign-e5268b6e-4931-42f1-b379-87f48eb41b1e" timestamp="2014-08-08T15:50:10.983728+00:00" xsi:type='campaign:CampaignType' version="1.1.1">
             <campaign:Title>Compromise of ATM Machines</campaign:Title>

--- a/documentation/idioms/cve/cve-in-exploit-target.xml
+++ b/documentation/idioms/cve/cve-in-exploit-target.xml
@@ -11,12 +11,9 @@
     http://stix.mitre.org/ExploitTarget-1 http://stix.mitre.org/XMLSchema/exploit_target/1.1.1/exploit_target.xsd
     http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd"
     id="example:STIXPackage-0196d980-60d9-4717-b7c5-bf7bc27a35d4"
-    timestamp="2014-05-08T09:00:00.000000Z"
+
     version="1.1.1"
     >
-    <stix:STIX_Header>
-        <stix:Title>Example CVE in an Exploit Target</stix:Title>
-    </stix:STIX_Header>
     <stix:Exploit_Targets>
         <stixCommon:Exploit_Target xsi:type="et:ExploitTargetType" id="example:et-48a276f7-a8d7-bba2-3575-e8a63fcd488" timestamp="2014-05-08T09:00:00.000000Z">
             <et:Title>Javascript vulnerability in MSIE 6-11</et:Title>

--- a/documentation/idioms/identity-group/identifying-a-threat-actor-group.xml
+++ b/documentation/idioms/identity-group/identifying-a-threat-actor-group.xml
@@ -17,7 +17,7 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
 	urn:oasis:names:tc:ciq:xal:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xAL.xsd
 	urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="example:Package-c9567f73-3803-415c-b06e-2b0622830e5d" version="1.1.1" timestamp="2014-11-19T23:39:03.893235+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="example:Package-c9567f73-3803-415c-b06e-2b0622830e5d" version="1.1.1">
     <stix:Threat_Actors>
         <stix:Threat_Actor id="example:threatactor-dfaa8d77-07e2-4e28-b2c8-92e9f7b04428" timestamp="2014-11-19T23:39:03.893348+00:00" xsi:type='ta:ThreatActorType' version="1.1.1">
             <ta:Title>Disco Team Threat Actor Group</ta:Title>

--- a/documentation/idioms/incident-vs-indicator/index.md
+++ b/documentation/idioms/incident-vs-indicator/index.md
@@ -75,7 +75,7 @@ One option in converting this data to STIX is to convert it to indicators: the *
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 data = json.load(open("data.json"))
 
-stix_package = STIXPackage(stix_header=STIXHeader(title=data['title'], package_intents='Indicators - Watchlist'))
+stix_package = STIXPackage()
 
 ttps = {}
 
@@ -97,7 +97,6 @@ for info in data['ips']:
 stix_package = STIXPackage.from_xml('sample-indicators.xml')
 
 data = {
-  'title': stix_package.stix_header.title,
   'indicators': {
   }
 }
@@ -157,7 +156,7 @@ The other approach would be to convert it to incidents: the **IP Address** is a 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 data = json.load(open("data.json"))
 
-stix_package = STIXPackage(stix_header=STIXHeader(title=data['title'], package_intents='Incident'))
+stix_package = STIXPackage()
 
 ttps = {}
 
@@ -185,7 +184,7 @@ for info in data['ips']:
 stix_package = STIXPackage.from_xml('sample-incidents.xml')
 
 data = {
-  'title': stix_package.stix_header.title,
+  
   'incidents': {
   }
 }
@@ -274,7 +273,7 @@ Finally, both an indicator and an incident could be created for each row, and li
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 data = json.load(open("data.json"))
 
-stix_package = STIXPackage(stix_header=STIXHeader(title=data['title'], package_intents='Incident'))
+stix_package = STIXPackage()
 
 ttps = {}
 
@@ -316,7 +315,7 @@ for info in data['ips']:
 stix_package = STIXPackage.from_xml('sample-combined.xml')
 
 data = {
-  'title': stix_package.stix_header.title,
+  
   'incidents': {
   }
 }

--- a/documentation/idioms/incident-vs-indicator/indicator-consumer.py
+++ b/documentation/idioms/incident-vs-indicator/indicator-consumer.py
@@ -13,7 +13,6 @@ def main():
   stix_package = STIXPackage.from_xml('sample-indicators.xml')
 
   data = {
-    'title': stix_package.stix_header.title,
     'indicators': {
     }
   }

--- a/documentation/idioms/incident-vs-indicator/indicator-producer.py
+++ b/documentation/idioms/incident-vs-indicator/indicator-producer.py
@@ -18,7 +18,7 @@ def main():
 
   data = json.load(open("data.json"))
 
-  stix_package = STIXPackage(stix_header=STIXHeader(title=data['title'], package_intents='Indicators - Watchlist'))
+  stix_package = STIXPackage()
 
   ttps = {}
 

--- a/documentation/idioms/incident-vs-indicator/sample-combined.xml
+++ b/documentation/idioms/incident-vs-indicator/sample-combined.xml
@@ -21,11 +21,8 @@
 	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-253035a6-257a-4bd7-8b95-309400428ec3" version="1.1.1" timestamp="2014-08-25T15:55:45.337000+00:00">
-    <stix:STIX_Header>
-        <stix:Title>IPs of Interest</stix:Title>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
-    </stix:STIX_Header>
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-253035a6-257a-4bd7-8b95-309400428ec3" version="1.1.1" >
+    
     <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
         <cybox:Observable id="example:Observable-6a93879e-58b9-47b0-a44a-77fdb0cf1bb7">
             <cybox:Object id="example:Address-7e4f44b8-a0f9-4940-9de4-da313b6a2827">

--- a/documentation/idioms/incident-vs-indicator/sample-combined.xml
+++ b/documentation/idioms/incident-vs-indicator/sample-combined.xml
@@ -1,45 +1,37 @@
 <stix:STIX_Package 
-	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
-	xmlns:cybox="http://cybox.mitre.org/cybox-2"
-	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
 	xmlns:AddressObj="http://cybox.mitre.org/objects#AddressObject-2"
+	xmlns:cybox="http://cybox.mitre.org/cybox-2"
+	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
 	xmlns:example="http://example.com"
 	xmlns:incident="http://stix.mitre.org/Incident-1"
 	xmlns:indicator="http://stix.mitre.org/Indicator-2"
-	xmlns:ttp="http://stix.mitre.org/TTP-1"
+	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:stixCommon="http://stix.mitre.org/common-1"
 	xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
-	xmlns:stix="http://stix.mitre.org/stix-1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="
-	http://cybox.mitre.org/common-2 http://cybox.mitre.org/XMLSchema/common/2.1/cybox_common.xsd
-	http://cybox.mitre.org/cybox-2 http://cybox.mitre.org/XMLSchema/core/2.1/cybox_core.xsd
-	http://cybox.mitre.org/default_vocabularies-2 http://cybox.mitre.org/XMLSchema/default_vocabularies/2.1/cybox_default_vocabularies.xsd
-	http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd
-	http://stix.mitre.org/Incident-1 http://stix.mitre.org/XMLSchema/incident/1.1.1/incident.xsd
-	http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.1.1/indicator.xsd
-	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
-	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
-	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-253035a6-257a-4bd7-8b95-309400428ec3" version="1.1.1" >
-    
+	xmlns:ttp="http://stix.mitre.org/TTP-1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="example:Package-32e6934f-a28c-4e8e-9ff0-588d353ab96e" version="1.1.1" >
+    <stix:STIX_Header>
+        <stix:Title>IPs of Interest</stix:Title>
+        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
+    </stix:STIX_Header>
     <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
-        <cybox:Observable id="example:Observable-6a93879e-58b9-47b0-a44a-77fdb0cf1bb7">
-            <cybox:Object id="example:Address-7e4f44b8-a0f9-4940-9de4-da313b6a2827">
+        <cybox:Observable id="example:Observable-f34cd03b-f924-4b0b-8447-353cb024d4f8">
+            <cybox:Object id="example:Address-9a8fbc6f-d402-46a7-9032-53d0214a86f7">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.1</AddressObj:Address_Value>
                 </cybox:Properties>
             </cybox:Object>
         </cybox:Observable>
-        <cybox:Observable id="example:Observable-f5677a60-16cf-4ff3-b42f-18d569febd64">
-            <cybox:Object id="example:Address-49332cbe-99d0-422d-a6f6-5dd7b8d0618b">
+        <cybox:Observable id="example:Observable-18568256-083a-44ee-ac85-669ac96dee2a">
+            <cybox:Object id="example:Address-37bd095b-1d95-4411-84db-b7a580b9d956">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.2</AddressObj:Address_Value>
                 </cybox:Properties>
             </cybox:Object>
         </cybox:Observable>
-        <cybox:Observable id="example:Observable-c4d3a92f-96fe-4a9a-97bd-9f7a8abf20fc">
-            <cybox:Object id="example:Address-27e6857d-e39f-4b45-9122-e6a4fa99f6f9">
+        <cybox:Observable id="example:Observable-81e7bcb2-d71f-4b88-96e9-2c1b2a3e8f53">
+            <cybox:Object id="example:Address-c2ccdde3-48ef-46ea-9531-f273ad918b2d">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.3</AddressObj:Address_Value>
                 </cybox:Properties>
@@ -47,121 +39,121 @@
         </cybox:Observable>
     </stix:Observables>
     <stix:Indicators>
-        <stix:Indicator id="example:indicator-de988b8f-538b-40d8-b4f3-36378ba18d48" timestamp="2014-08-25T15:55:45.338000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
+        <stix:Indicator id="example:indicator-239fdc6b-bee7-4cc6-8987-938e517b2eda" timestamp="2015-05-12T18:55:02.443600+00:00" xsi:type='indicator:IndicatorType'>
             <indicator:Title>192.168.1.1</indicator:Title>
-            <indicator:Observable id="example:Observable-c80170c3-64f0-49a7-b16c-be9dc290583f">
-                <cybox:Object id="example:Address-85953adb-21ba-447c-8d8b-df8fe4d7e894">
+            <indicator:Observable id="example:Observable-f699a22f-7a02-4b4a-bd41-0ba139956d10">
+                <cybox:Object id="example:Address-e21d904d-ac02-471c-825c-0b5cae4fb4d8">
                     <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                         <AddressObj:Address_Value condition="Equals">192.168.1.1</AddressObj:Address_Value>
                     </cybox:Properties>
                 </cybox:Object>
             </indicator:Observable>
             <indicator:Indicated_TTP>
-                <stixCommon:TTP idref="example:ttp-e16098ed-8135-43b0-96d1-1d93e52fdab2" xsi:type='ttp:TTPType' version="1.1.1"/>
+                <stixCommon:TTP idref="example:ttp-141c40d1-8e7b-415a-9698-698df1e9f21c" xsi:type='ttp:TTPType'/>
             </indicator:Indicated_TTP>
         </stix:Indicator>
-        <stix:Indicator id="example:indicator-132f994f-627e-453b-97e4-d2fc0d9b6143" timestamp="2014-08-25T15:55:45.341000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
+        <stix:Indicator id="example:indicator-899796d3-4e59-4ebf-a25d-c01be6caefbc" timestamp="2015-05-12T18:55:02.447308+00:00" xsi:type='indicator:IndicatorType'>
             <indicator:Title>192.168.1.2</indicator:Title>
-            <indicator:Observable id="example:Observable-19be41b3-b51c-4f73-b388-4978ad5f4985">
-                <cybox:Object id="example:Address-1059630d-b0bb-483b-990f-553880b704f1">
+            <indicator:Observable id="example:Observable-77a00f4e-f239-40b1-91cc-67a71ccb9831">
+                <cybox:Object id="example:Address-1d6d3d7a-fe00-42f2-958c-4cffa6b46014">
                     <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                         <AddressObj:Address_Value condition="Equals">192.168.1.2</AddressObj:Address_Value>
                     </cybox:Properties>
                 </cybox:Object>
             </indicator:Observable>
             <indicator:Indicated_TTP>
-                <stixCommon:TTP idref="example:ttp-6811a8b7-cbc7-4747-86ab-1f26ee7b84ba" xsi:type='ttp:TTPType' version="1.1.1"/>
+                <stixCommon:TTP idref="example:ttp-40af4f5a-bc84-4d28-a0fa-cef1f7c004a9" xsi:type='ttp:TTPType'/>
             </indicator:Indicated_TTP>
         </stix:Indicator>
-        <stix:Indicator id="example:indicator-e84adf12-d390-4ad8-b830-72c48617717d" timestamp="2014-08-25T15:55:45.343000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
+        <stix:Indicator id="example:indicator-8dee4c95-33f1-4bc0-b254-dfca8647578c" timestamp="2015-05-12T18:55:02.450375+00:00" xsi:type='indicator:IndicatorType'>
             <indicator:Title>192.168.1.3</indicator:Title>
-            <indicator:Observable id="example:Observable-e3394c5f-fce1-4ad3-8bb5-52ce5b7c44e9">
-                <cybox:Object id="example:Address-9449960e-1606-4d04-91b2-d8331bfe548b">
+            <indicator:Observable id="example:Observable-b978fc39-4c3b-495c-a6de-6904e16bdcc0">
+                <cybox:Object id="example:Address-7c407a38-75cf-46d6-93fa-a9f598bcf3a5">
                     <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                         <AddressObj:Address_Value condition="Equals">192.168.1.3</AddressObj:Address_Value>
                     </cybox:Properties>
                 </cybox:Object>
             </indicator:Observable>
             <indicator:Indicated_TTP>
-                <stixCommon:TTP idref="example:ttp-e16098ed-8135-43b0-96d1-1d93e52fdab2" xsi:type='ttp:TTPType' version="1.1.1"/>
+                <stixCommon:TTP idref="example:ttp-141c40d1-8e7b-415a-9698-698df1e9f21c" xsi:type='ttp:TTPType'/>
             </indicator:Indicated_TTP>
         </stix:Indicator>
     </stix:Indicators>
     <stix:TTPs>
-        <stix:TTP id="example:ttp-e16098ed-8135-43b0-96d1-1d93e52fdab2" timestamp="2014-08-25T15:55:45.338000+00:00" xsi:type='ttp:TTPType' version="1.1.1">
+        <stix:TTP id="example:ttp-141c40d1-8e7b-415a-9698-698df1e9f21c" timestamp="2015-05-12T18:55:02.443335+00:00" xsi:type='ttp:TTPType'>
             <ttp:Title>ZBot</ttp:Title>
         </stix:TTP>
-        <stix:TTP id="example:ttp-6811a8b7-cbc7-4747-86ab-1f26ee7b84ba" timestamp="2014-08-25T15:55:45.341000+00:00" xsi:type='ttp:TTPType' version="1.1.1">
+        <stix:TTP id="example:ttp-40af4f5a-bc84-4d28-a0fa-cef1f7c004a9" timestamp="2015-05-12T18:55:02.447069+00:00" xsi:type='ttp:TTPType'>
             <ttp:Title>iSpy2</ttp:Title>
         </stix:TTP>
     </stix:TTPs>
     <stix:Incidents>
-        <stix:Incident id="example:incident-d6f8f6d6-e9ea-4d8f-b066-20a492ac9561" timestamp="2014-08-25T15:55:45.339000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-c49f0c67-b9e4-4e92-9e0a-2f10b546bd5b" timestamp="2015-05-12T18:55:02.444850+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.1</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-01T09:23:23+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Indicators>
                 <incident:Related_Indicator>
-                    <stixCommon:Indicator idref="example:indicator-de988b8f-538b-40d8-b4f3-36378ba18d48" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1"/>
+                    <stixCommon:Indicator idref="example:indicator-239fdc6b-bee7-4cc6-8987-938e517b2eda" xsi:type='indicator:IndicatorType'/>
                 </incident:Related_Indicator>
             </incident:Related_Indicators>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-6a93879e-58b9-47b0-a44a-77fdb0cf1bb7">
+                    <stixCommon:Observable idref="example:Observable-f34cd03b-f924-4b0b-8447-353cb024d4f8">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-e16098ed-8135-43b0-96d1-1d93e52fdab2" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-141c40d1-8e7b-415a-9698-698df1e9f21c" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>
-        <stix:Incident id="example:incident-50ee7517-d1b0-4dfc-ba9d-f62089f3ddee" timestamp="2014-08-25T15:55:45.341000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-b1061fca-a40a-411b-88dd-6e43ce54906f" timestamp="2015-05-12T18:55:02.448489+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.2</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-03T11:21:27+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Indicators>
                 <incident:Related_Indicator>
-                    <stixCommon:Indicator idref="example:indicator-132f994f-627e-453b-97e4-d2fc0d9b6143" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1"/>
+                    <stixCommon:Indicator idref="example:indicator-899796d3-4e59-4ebf-a25d-c01be6caefbc" xsi:type='indicator:IndicatorType'/>
                 </incident:Related_Indicator>
             </incident:Related_Indicators>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-f5677a60-16cf-4ff3-b42f-18d569febd64">
+                    <stixCommon:Observable idref="example:Observable-18568256-083a-44ee-ac85-669ac96dee2a">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-6811a8b7-cbc7-4747-86ab-1f26ee7b84ba" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-40af4f5a-bc84-4d28-a0fa-cef1f7c004a9" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>
-        <stix:Incident id="example:incident-2bedee92-c2d8-4b21-bb97-a9ec40641923" timestamp="2014-08-25T15:55:45.344000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-47fa9069-d2b2-442d-9e98-f77c62f342b8" timestamp="2015-05-12T18:55:02.451196+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.3</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-04T17:45:54+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Indicators>
                 <incident:Related_Indicator>
-                    <stixCommon:Indicator idref="example:indicator-e84adf12-d390-4ad8-b830-72c48617717d" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1"/>
+                    <stixCommon:Indicator idref="example:indicator-8dee4c95-33f1-4bc0-b254-dfca8647578c" xsi:type='indicator:IndicatorType'/>
                 </incident:Related_Indicator>
             </incident:Related_Indicators>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-c4d3a92f-96fe-4a9a-97bd-9f7a8abf20fc">
+                    <stixCommon:Observable idref="example:Observable-81e7bcb2-d71f-4b88-96e9-2c1b2a3e8f53">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-e16098ed-8135-43b0-96d1-1d93e52fdab2" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-141c40d1-8e7b-415a-9698-698df1e9f21c" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>

--- a/documentation/idioms/incident-vs-indicator/sample-incidents.xml
+++ b/documentation/idioms/incident-vs-indicator/sample-incidents.xml
@@ -1,43 +1,36 @@
 <stix:STIX_Package 
-	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
-	xmlns:cybox="http://cybox.mitre.org/cybox-2"
-	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
 	xmlns:AddressObj="http://cybox.mitre.org/objects#AddressObject-2"
+	xmlns:cybox="http://cybox.mitre.org/cybox-2"
+	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
 	xmlns:example="http://example.com"
 	xmlns:incident="http://stix.mitre.org/Incident-1"
-	xmlns:ttp="http://stix.mitre.org/TTP-1"
+	xmlns:stix="http://stix.mitre.org/stix-1"
 	xmlns:stixCommon="http://stix.mitre.org/common-1"
 	xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
-	xmlns:stix="http://stix.mitre.org/stix-1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="
-	http://cybox.mitre.org/common-2 http://cybox.mitre.org/XMLSchema/common/2.1/cybox_common.xsd
-	http://cybox.mitre.org/cybox-2 http://cybox.mitre.org/XMLSchema/core/2.1/cybox_core.xsd
-	http://cybox.mitre.org/default_vocabularies-2 http://cybox.mitre.org/XMLSchema/default_vocabularies/2.1/cybox_default_vocabularies.xsd
-	http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd
-	http://stix.mitre.org/Incident-1 http://stix.mitre.org/XMLSchema/incident/1.1.1/incident.xsd
-	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
-	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
-	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-747d7c92-1aaf-418c-b5e9-174ef68c47fc" version="1.1.1" >
-
+	xmlns:ttp="http://stix.mitre.org/TTP-1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="example:Package-42005e70-bc53-4261-adf4-cb344ad3a343" version="1.1.1" >
+    <stix:STIX_Header>
+        <stix:Title>IPs of Interest</stix:Title>
+        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
+    </stix:STIX_Header>
     <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
-        <cybox:Observable id="example:Observable-57501ad9-3b55-44aa-a084-eb55b1a84301">
-            <cybox:Object id="example:Address-cbff060f-0010-4f36-9e45-48df756871e1">
+        <cybox:Observable id="example:Observable-3b219731-e33f-4da3-9800-6e2c63965778">
+            <cybox:Object id="example:Address-16729f62-f242-4750-8192-2d26133369bd">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.1</AddressObj:Address_Value>
                 </cybox:Properties>
             </cybox:Object>
         </cybox:Observable>
-        <cybox:Observable id="example:Observable-1dd5787b-b571-43ec-a06e-bbf8496ee5b1">
-            <cybox:Object id="example:Address-15a515f4-a79c-466f-8ddc-cb1710a8b97b">
+        <cybox:Observable id="example:Observable-58a3a289-b24b-4f6a-bc76-cc50a3b95af1">
+            <cybox:Object id="example:Address-2e8a69cb-3a2d-48fd-b2af-71ad104806af">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.2</AddressObj:Address_Value>
                 </cybox:Properties>
             </cybox:Object>
         </cybox:Observable>
-        <cybox:Observable id="example:Observable-7793f79e-09a8-41ce-bcea-d7753c5c5edb">
-            <cybox:Object id="example:Address-c3c9dbb5-d0cf-43f3-9f41-c6b860aa6efb">
+        <cybox:Observable id="example:Observable-c04d617b-69f0-461a-9f77-4213a05b0c84">
+            <cybox:Object id="example:Address-cbe46012-74d7-4f21-b295-22e7ec12439d">
                 <cybox:Properties xsi:type="AddressObj:AddressObjectType" category="ipv4-addr">
                     <AddressObj:Address_Value>192.168.1.3</AddressObj:Address_Value>
                 </cybox:Properties>
@@ -45,65 +38,65 @@
         </cybox:Observable>
     </stix:Observables>
     <stix:TTPs>
-        <stix:TTP id="example:ttp-f0c26887-610b-4724-80c6-5bd4e0354df9" timestamp="2014-08-25T13:49:37.079000+00:00" xsi:type='ttp:TTPType' version="1.1.1">
+        <stix:TTP id="example:ttp-c37ffe2f-7de8-4853-8670-abd2272658c4" timestamp="2015-05-12T18:57:34.417350+00:00" xsi:type='ttp:TTPType'>
             <ttp:Title>ZBot</ttp:Title>
         </stix:TTP>
-        <stix:TTP id="example:ttp-a3bca8df-4904-433a-abf0-614a30407f5d" timestamp="2014-08-25T13:49:37.081000+00:00" xsi:type='ttp:TTPType' version="1.1.1">
+        <stix:TTP id="example:ttp-06cc41f6-2ebf-4ec0-b385-afea21974e70" timestamp="2015-05-12T18:57:34.418836+00:00" xsi:type='ttp:TTPType'>
             <ttp:Title>iSpy2</ttp:Title>
         </stix:TTP>
     </stix:TTPs>
     <stix:Incidents>
-        <stix:Incident id="example:incident-da4e5808-0159-497a-be65-a65c8974f027" timestamp="2014-08-25T13:49:37.079000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-91776ba4-e425-4b02-823f-9387c5a062f6" timestamp="2015-05-12T18:57:34.417525+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.1</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-01T09:23:23+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-57501ad9-3b55-44aa-a084-eb55b1a84301">
+                    <stixCommon:Observable idref="example:Observable-3b219731-e33f-4da3-9800-6e2c63965778">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-f0c26887-610b-4724-80c6-5bd4e0354df9" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-c37ffe2f-7de8-4853-8670-abd2272658c4" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>
-        <stix:Incident id="example:incident-74112763-ca88-48a5-8114-eec2cc903f95" timestamp="2014-08-25T13:49:37.081000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-46c7753f-7892-450e-9082-2f937ea220bd" timestamp="2015-05-12T18:57:34.419015+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.2</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-03T11:21:27+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-1dd5787b-b571-43ec-a06e-bbf8496ee5b1">
+                    <stixCommon:Observable idref="example:Observable-58a3a289-b24b-4f6a-bc76-cc50a3b95af1">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-a3bca8df-4904-433a-abf0-614a30407f5d" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-06cc41f6-2ebf-4ec0-b385-afea21974e70" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>
-        <stix:Incident id="example:incident-2fdf0dc6-2124-4c56-ac4c-fbe8dba288c1" timestamp="2014-08-25T13:49:37.082000+00:00" xsi:type='incident:IncidentType' version="1.1.1">
+        <stix:Incident id="example:incident-f8dc272b-7391-47c2-a07e-4c5d1e0bbab7" timestamp="2015-05-12T18:57:34.420003+00:00" xsi:type='incident:IncidentType'>
             <incident:Title>192.168.1.3</incident:Title>
             <incident:Time>
                 <incident:First_Malicious_Action precision="second">2014-01-04T17:45:54+00:00</incident:First_Malicious_Action>
             </incident:Time>
             <incident:Related_Observables>
                 <incident:Related_Observable>
-                    <stixCommon:Observable idref="example:Observable-7793f79e-09a8-41ce-bcea-d7753c5c5edb">
+                    <stixCommon:Observable idref="example:Observable-c04d617b-69f0-461a-9f77-4213a05b0c84">
                     </stixCommon:Observable>
                 </incident:Related_Observable>
             </incident:Related_Observables>
             <incident:Leveraged_TTPs>
                 <incident:Leveraged_TTP>
                     <stixCommon:Relationship>Used Malware</stixCommon:Relationship>
-                    <stixCommon:TTP idref="example:ttp-f0c26887-610b-4724-80c6-5bd4e0354df9" xsi:type='ttp:TTPType' version="1.1.1"/>
+                    <stixCommon:TTP idref="example:ttp-c37ffe2f-7de8-4853-8670-abd2272658c4" xsi:type='ttp:TTPType'/>
                 </incident:Leveraged_TTP>
             </incident:Leveraged_TTPs>
         </stix:Incident>

--- a/documentation/idioms/incident-vs-indicator/sample-incidents.xml
+++ b/documentation/idioms/incident-vs-indicator/sample-incidents.xml
@@ -19,11 +19,8 @@
 	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-747d7c92-1aaf-418c-b5e9-174ef68c47fc" version="1.1.1" timestamp="2014-08-25T13:49:37.078000+00:00">
-    <stix:STIX_Header>
-        <stix:Title>IPs of Interest</stix:Title>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
-    </stix:STIX_Header>
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-747d7c92-1aaf-418c-b5e9-174ef68c47fc" version="1.1.1" >
+
     <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
         <cybox:Observable id="example:Observable-57501ad9-3b55-44aa-a084-eb55b1a84301">
             <cybox:Object id="example:Address-cbff060f-0010-4f36-9e45-48df756871e1">

--- a/documentation/idioms/incident-vs-indicator/sample-indicators.xml
+++ b/documentation/idioms/incident-vs-indicator/sample-indicators.xml
@@ -21,11 +21,8 @@
 	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-58d4989b-33f3-411a-b524-02e40f1a115d" version="1.1.1" timestamp="2014-08-22T20:17:38.959000+00:00">
-    <stix:STIX_Header>
-        <stix:Title>IP Indicators</stix:Title>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
-    </stix:STIX_Header>
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-58d4989b-33f3-411a-b524-02e40f1a115d" version="1.1.1" >
+ 
     <stix:Indicators>
         <stix:Indicator id="example:indicator-0756a255-6623-4226-8356-015396918b38" timestamp="2014-08-22T20:17:38.959000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>192.168.1.1</indicator:Title>

--- a/documentation/idioms/indicator-w-kill-chain/index.md
+++ b/documentation/idioms/indicator-w-kill-chain/index.md
@@ -19,34 +19,29 @@ In the example below, we define a kill chain and include a reference to one of i
 ## Implementation
 
 {% include start_tabs.html tabs="XML|Python Producer|Python Consumer" name="indicator-w-kill-chain" %}{% highlight xml linenos %}
-<stix:STIX_Package>
-    <stix:STIX_Header>
-        <stix:Title>Kill Chain Definition</stix:Title>
-    </stix:STIX_Header>
-    <stix:Indicators>
-        <stix:Indicator id="example:indicator-efe1dec4-2f86-44ce-9977-543d15507892" timestamp="2014-10-09T21:38:50.631509+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
-            <indicator:Title>Malicious executable</indicator:Title>
-            <indicator:Description>Resident binary which implements infostealing and credit card grabber</indicator:Description>
-            <indicator:Kill_Chain_Phases>
-                <stixCommon:Kill_Chain_Phase phase_id="example:killchainphase-32628418-b677-4bb3-8543-3e7e6c0c7500" kill_chain_id="example:killchain-13c00902-fc04-4d63-9362-29afedd50805"/>
-            </indicator:Kill_Chain_Phases>
-        </stix:Indicator>
-    </stix:Indicators>
-    <stix:TTPs>
-        <stix:Kill_Chains>
-            <stixCommon:Kill_Chain id="example:killchain-13c00902-fc04-4d63-9362-29afedd50805" name="Organization-specific Kill Chain">
-                <stixCommon:Kill_Chain_Phase name="Infect Machine" phase_id="example:killchainphase-32628418-b677-4bb3-8543-3e7e6c0c7500"/>
-                <stixCommon:Kill_Chain_Phase name="Exfiltrate Data" phase_id="example:killchainphase-3ffb6f6d-042f-49a4-8eea-0e0b6686090b"/>
-            </stixCommon:Kill_Chain>
-        </stix:Kill_Chains>
-    </stix:TTPs>
-</stix:STIX_Package>
+
+<stix:Indicators>
+    <stix:Indicator id="example:indicator-efe1dec4-2f86-44ce-9977-543d15507892" timestamp="2014-10-09T21:38:50.631509+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
+        <indicator:Title>Malicious executable</indicator:Title>
+        <indicator:Description>Resident binary which implements infostealing and credit card grabber</indicator:Description>
+        <indicator:Kill_Chain_Phases>
+            <stixCommon:Kill_Chain_Phase phase_id="example:killchainphase-32628418-b677-4bb3-8543-3e7e6c0c7500" kill_chain_id="example:killchain-13c00902-fc04-4d63-9362-29afedd50805"/>
+        </indicator:Kill_Chain_Phases>
+    </stix:Indicator>
+</stix:Indicators>
+<stix:TTPs>
+    <stix:Kill_Chains>
+        <stixCommon:Kill_Chain id="example:killchain-13c00902-fc04-4d63-9362-29afedd50805" name="Organization-specific Kill Chain">
+            <stixCommon:Kill_Chain_Phase name="Infect Machine" phase_id="example:killchainphase-32628418-b677-4bb3-8543-3e7e6c0c7500"/>
+            <stixCommon:Kill_Chain_Phase name="Exfiltrate Data" phase_id="example:killchainphase-3ffb6f6d-042f-49a4-8eea-0e0b6686090b"/>
+        </stixCommon:Kill_Chain>
+    </stix:Kill_Chains>
+</stix:TTPs>
+
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 stix_pkg = STIXPackage()
-stix_header = STIXHeader()
-stix_header.title = "Kill Chain Definition"
-stix_pkg.stix_header = stix_header
+
 
 # make indicator 
 ind = Indicator()

--- a/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain.xml
+++ b/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain.xml
@@ -11,10 +11,8 @@
 	http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.1.1/indicator.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-de31ca3a-2561-4f73-ab5b-e28610b2bef8" version="1.1.1" timestamp="2014-10-09T21:38:50.631390+00:00">
-    <stix:STIX_Header>
-        <stix:Title>Kill Chain Definition</stix:Title>
-    </stix:STIX_Header>
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-de31ca3a-2561-4f73-ab5b-e28610b2bef8" version="1.1.1">
+
     <stix:Indicators>
         <stix:Indicator id="example:indicator-efe1dec4-2f86-44ce-9977-543d15507892" timestamp="2014-10-09T21:38:50.631509+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>Malicious executable</indicator:Title>

--- a/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain_producer.py
+++ b/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain_producer.py
@@ -10,9 +10,7 @@ from stix.common.kill_chains import KillChain,KillChainPhase, KillChainPhaseRefe
 
 def main():
     stix_pkg = STIXPackage()
-    stix_header = STIXHeader()
-    stix_header.title = "Kill Chain Definition"
-    stix_pkg.stix_header = stix_header
+
 
     # make indicator 
     ind = Indicator()

--- a/documentation/idioms/indicators-to-campaigns/new-style.xml
+++ b/documentation/idioms/indicators-to-campaigns/new-style.xml
@@ -21,7 +21,7 @@
         http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.1.1/indicator.xsd
         http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
         http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea965ac1-4380-4d66-bddc-bad9912ee592" version="1.1.1" timestamp="2014-09-09T19:58:39.607000+00:00">
+        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea965ac1-4380-4d66-bddc-bad9912ee592" version="1.1.1" >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-c43a0a05-e8d2-4f64-ae37-3f3fb153f8d9" timestamp="2014-09-09T19:58:39.608000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>IP Address for known C2 Channel</indicator:Title>

--- a/documentation/idioms/indicators-to-campaigns/old-style.xml
+++ b/documentation/idioms/indicators-to-campaigns/old-style.xml
@@ -22,7 +22,7 @@
         http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.1.1/indicator.xsd
         http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
         http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea965ac1-4380-4d66-bddc-bad9912ee592" version="1.1.1" timestamp="2014-09-09T19:58:39.607000+00:00">
+        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea965ac1-4380-4d66-bddc-bad9912ee592" version="1.1.1" >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-c43a0a05-e8d2-4f64-ae37-3f3fb153f8d9" timestamp="2014-09-09T19:58:39.608000+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>IP Address for known C2 Channel</indicator:Title>

--- a/documentation/idioms/industry-sector/victim-targeting-sector.xml
+++ b/documentation/idioms/industry-sector/victim-targeting-sector.xml
@@ -13,7 +13,7 @@
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/extensions/Identity#CIQIdentity3.0-1 http://stix.mitre.org/XMLSchema/extensions/identity/ciq_3.0/1.1.1/ciq_3.0_identity.xsd
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd
-	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="example:Package-e5114ee8-303f-4428-98ff-9499f099c961" version="1.1.1" timestamp="2014-09-09T14:38:08.678427+00:00">
+	urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd" id="example:Package-e5114ee8-303f-4428-98ff-9499f099c961" version="1.1.1" >
     <stix:TTPs>
         <stix:TTP id="example:ttp-651e69a6-1ee4-4a9c-b9a1-3e9919fc695f" timestamp="2014-09-09T14:38:08.678310+00:00" xsi:type='ttp:TTPType' version="1.1.1">
             <ttp:Title>Victim Targeting: Electricity Sector and Industrial Control System Sector</ttp:Title>

--- a/documentation/idioms/kill-chain/index.md
+++ b/documentation/idioms/kill-chain/index.md
@@ -55,10 +55,6 @@ The example below demonstrates how to reference the kill chains (defined as expl
 </stix:TTPs>
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 stix_pkg = STIXPackage()
-stix_header = STIXHeader()
-stix_header.title = "Kill Chain Definition"
-stix_pkg.stix_header = stix_header
-
 
 # create LM-style kill chain 
 # REF: http://stix.mitre.org/language/version1.1.1/stix_v1.1.1_lmco_killchain.xml

--- a/documentation/idioms/kill-chain/kill-chain.xml
+++ b/documentation/idioms/kill-chain/kill-chain.xml
@@ -15,10 +15,8 @@
         http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.1.1/indicator.xsd
         http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
         http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-91d9b5a2-b63b-431b-ab56-aba30ab36809" version="1.1.1" timestamp="2014-10-21T21:10:09.423000+00:00">
-    <stix:STIX_Header>
-        <stix:Title>Kill Chain Definition</stix:Title>
-    </stix:STIX_Header>
+        http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-91d9b5a2-b63b-431b-ab56-aba30ab36809" version="1.1.1" >
+
     <stix:Indicators>
         <stix:Indicator id="example:indicator-f33c2b75-aa60-4ffb-9829-3746ef233311" timestamp="2014-10-21T21:10:09.423000+00:00" xsi:type='indicator:IndicatorType'>
             <indicator:Kill_Chain_Phases>

--- a/documentation/idioms/kill-chain/kill-chain_producer.py
+++ b/documentation/idioms/kill-chain/kill-chain_producer.py
@@ -12,9 +12,6 @@ from stix.common.kill_chains import KillChainPhase, KillChain, KillChainPhaseRef
 
 def main():
     stix_pkg = STIXPackage()
-    stix_header = STIXHeader()
-    stix_header.title = "Kill Chain Definition"
-    stix_pkg.stix_header = stix_header
 
 
     # create LM-style kill chain 

--- a/documentation/idioms/malicious-email-attachment/malicious-email-indicator-with-attachment.xml
+++ b/documentation/idioms/malicious-email-attachment/malicious-email-indicator-with-attachment.xml
@@ -23,7 +23,7 @@
 	http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-8b8ed1c1-f01d-4393-ac65-97017ed15876" version="1.1.1" timestamp="2014-10-31T15:52:13.126609+00:00">
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-8b8ed1c1-f01d-4393-ac65-97017ed15876" version="1.1.1" >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-8cf9236f-1b96-493d-98be-0c1c1e8b62d7" timestamp="2014-10-31T15:52:13.127931+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>Malicious E-mail</indicator:Title>

--- a/documentation/idioms/malicious-url/indicator-for-malicious-url.xml
+++ b/documentation/idioms/malicious-url/indicator-for-malicious-url.xml
@@ -19,7 +19,6 @@
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" 
 	id="example:Package-8fab937e-b694-11e3-b71c-0800271e87d2" 
-	timestamp="2014-05-08T09:00:00.000000Z"
 	version="1.1.1">
     <stix:Indicators>
     	<stix:Indicator id="example:Indicator-d81f86b9-975b-bc0b-775e-810c5ad45a4f" xsi:type='indicator:IndicatorType'>

--- a/documentation/idioms/malware-hash/malware-indicator-for-file-hash.xml
+++ b/documentation/idioms/malware-hash/malware-indicator-for-file-hash.xml
@@ -22,7 +22,6 @@
 	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" 
 	id="example:Package-fdd39a2e-b67c-11e3-bcc9-f01faf20d111" 
 	version="1.1.1"
-	timestamp="2014-05-08T09:00:00.000000Z"
     >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-a932fcc6-e032-176c-126f-cb970a5a1ade" xsi:type='indicator:IndicatorType' timestamp="2014-05-08T09:00:00.000000Z">

--- a/documentation/idioms/openioc-test-mechanism/openioc-test-mechanism.xml
+++ b/documentation/idioms/openioc-test-mechanism/openioc-test-mechanism.xml
@@ -17,7 +17,7 @@
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/extensions/TestMechanism#OpenIOC2010-1 http://stix.mitre.org/XMLSchema/extensions/test_mechanism/open_ioc_2010/1.1.1/open_ioc_2010_test_mechanism.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-6ed0af26-fcb9-49be-9014-f119770f267a" version="1.1.1" timestamp="2014-06-20T20:53:08.437984+00:00">
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-6ed0af26-fcb9-49be-9014-f119770f267a" version="1.1.1" >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-b92194e0-da61-4a32-9034-1148123b0f7a" timestamp="2014-06-20T20:53:08.440812+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>Zeus</indicator:Title>

--- a/documentation/idioms/related-observables/incident-with-related-observables.xml
+++ b/documentation/idioms/related-observables/incident-with-related-observables.xml
@@ -17,7 +17,7 @@
 	http://stix.mitre.org/Incident-1 http://stix.mitre.org/XMLSchema/incident/1.1.1/incident.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-035391ea-ef0d-48c9-ae9b-d50452fcb296" version="1.1.1" timestamp="2014-09-15T14:37:54.297052+00:00">
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-035391ea-ef0d-48c9-ae9b-d50452fcb296" version="1.1.1" >
     <stix:Incidents>
         <stix:Incident id="example:incident-84d86106-d801-489b-87b6-d56bac58e6c1" timestamp="2014-09-15T14:37:54.297669+00:00" xsi:type='incident:IncidentType' version="1.1.1">
             <incident:Title>Malicious files detected</incident:Title>

--- a/documentation/idioms/simple-incident/index.md
+++ b/documentation/idioms/simple-incident/index.md
@@ -39,10 +39,6 @@ Note that timestamps describing the incident should be represented under `incide
 
 {% include start_tabs.html tabs="XML|Python Producer|Python Consumer" name="simple-incident" %}{% highlight xml linenos  %}
 <stix:STIX_Package >
-    <stix:STIX_Header>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
-        <stix:Description>Sample breach report</stix:Description>
-    </stix:STIX_Header>
     <stix:Incidents>
         <stix:Incident id="example:incident-8236b4a2-abe0-4b56-9347-288005c4bb92" timestamp="2014-11-18T23:40:08.061362+00:00" xsi:type='incident:IncidentType' version="1.1.1">
             <incident:Title>Breach of Cyber Tech Dynamics</incident:Title>
@@ -80,12 +76,6 @@ Note that timestamps describing the incident should be represented under `incide
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 # setup stix document
 stix_package = STIXPackage()
-stix_header = STIXHeader()
-
-stix_header.description = "Sample breach report" 
-stix_header.add_package_intent ("Incident")
-
-stix_package.stix_header = stix_header
 
 # add incident and confidence
 breach = Incident()
@@ -129,7 +119,7 @@ print stix_package
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print "== INCIDENT =="
-print "Package: " + str(pkg.stix_header.description)
+
 for inc in pkg.incidents:
     print "---"
     print "Reporter: " + inc.reporter.identity.name

--- a/documentation/idioms/simple-incident/sample.xml
+++ b/documentation/idioms/simple-incident/sample.xml
@@ -11,11 +11,7 @@
 	http://stix.mitre.org/Incident-1 http://stix.mitre.org/XMLSchema/incident/1.1.1/incident.xsd
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ec96d2a6-5a95-48f2-93c0-b3b2198633ca" version="1.1.1" timestamp="2014-11-18T23:40:08.061172+00:00">
-    <stix:STIX_Header>
-        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Incident</stix:Package_Intent>
-        <stix:Description>Sample breach report</stix:Description>
-    </stix:STIX_Header>
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ec96d2a6-5a95-48f2-93c0-b3b2198633ca" version="1.1.1">
     <stix:Incidents>
         <stix:Incident id="example:incident-8236b4a2-abe0-4b56-9347-288005c4bb92" timestamp="2014-11-18T23:40:08.061362+00:00" xsi:type='incident:IncidentType' version="1.1.1">
             <incident:Title>Breach of Cyber Tech Dynamics</incident:Title>

--- a/documentation/idioms/simple-incident/simple-incident_consumer.py
+++ b/documentation/idioms/simple-incident/simple-incident_consumer.py
@@ -7,7 +7,7 @@ from stix.core import STIXPackage, STIXHeader
 
 def parse_stix( pkg ):
     print "== INCIDENT =="
-    print "Package: " + str(pkg.stix_header.description)
+    
     for inc in pkg.incidents:
         print "---"
         print "Reporter: " + inc.reporter.identity.name

--- a/documentation/idioms/simple-incident/simple-incident_producer.py
+++ b/documentation/idioms/simple-incident/simple-incident_producer.py
@@ -19,12 +19,7 @@ from stix.extensions.marking.simple_marking import SimpleMarkingStructure
 def build_stix( ):
     # setup stix document
     stix_package = STIXPackage()
-    stix_header = STIXHeader()
 
-    stix_header.description = "Sample breach report" 
-    stix_header.add_package_intent ("Incident")
-
-    stix_package.stix_header = stix_header
 
     # add incident and confidence
     breach = Incident()

--- a/documentation/idioms/snort-test-mechanism/snort-test-mechanism.xml
+++ b/documentation/idioms/snort-test-mechanism/snort-test-mechanism.xml
@@ -17,7 +17,7 @@
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/extensions/TestMechanism#Snort-1 http://stix.mitre.org/XMLSchema/extensions/test_mechanism/snort/1.1.1/snort_test_mechanism.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea99d4d4-1ae7-4120-9ebe-67ed4783fb36" version="1.1.1" timestamp="2014-06-20T15:16:56.986347+00:00">
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea99d4d4-1ae7-4120-9ebe-67ed4783fb36" version="1.1.1">
     <stix:Indicators>
         <stix:Indicator id="example:indicator-567b201c-4fd5-4bde-a5db-42abc340807a" timestamp="2014-06-20T15:16:56.987616+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>Snort Signature for Heartbleed</indicator:Title>

--- a/documentation/idioms/victim-targeting/victim-targeting.xml
+++ b/documentation/idioms/victim-targeting/victim-targeting.xml
@@ -18,12 +18,8 @@
     http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
     http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd"
     id="example:STIXPackage-bf35a4b5-e102-463d-9105-4d7a6e2d78bc"
-    timestamp="2014-05-08T09:00:00.000000Z"
     version="1.1.1"
     >
-    <stix:STIX_Header>
-        <stix:Title>Example Victim Targeting for a Campaign</stix:Title>
-    </stix:STIX_Header>
     <stix:TTPs>
         <stix:TTP xsi:type="ttp:TTPType" id="example:ttp-4fde045a-b25f-f035-e8d0-29c9d5130cd9" timestamp="2014-05-08T09:00:00.000000Z">
             <ttp:Title>Victim Targeting: Customer PII and Financial Data</ttp:Title>

--- a/documentation/idioms/wrapper/index.md
+++ b/documentation/idioms/wrapper/index.md
@@ -43,7 +43,6 @@ One other note about this example is the XPath used in the data markings. Becaus
 
 {% highlight xml linenos %}
 <stix:STIX_Header>
-    <stix:Title>Example Plain Wrapper Around Multiple Reports</stix:Title>
     <stix:Information_Source>
         <stixCommon:Identity>
             <stixCommon:Name>Government Sharing Program - GSP</stixCommon:Name>
@@ -52,10 +51,8 @@ One other note about this example is the XPath used in the data markings. Becaus
 </stix:STIX_Header>
 <stix:Related_Packages>
     <stix:Related_Package>
-        <stix:Package id="example:package-ca6e215c-fbb7-4b7a-b678-632562f85e93" timestamp="2014-02-20T09:00:00.000000Z" version="1.1">
+        <stix:Package id="example:package-ca6e215c-fbb7-4b7a-b678-632562f85e93"  version="1.1">
             <stix:STIX_Header>
-                <stix:Title>Report on Adversary Alpha's Campaign against the Industrial Control Sector</stix:Title>
-                <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Campaign Characterization</stix:Package_Intent>
                 <stix:Handling>
                     <markings:Marking>
                         <markings:Controlled_Structure>../../../../descendant-or-self::node()</markings:Controlled_Structure>
@@ -66,10 +63,9 @@ One other note about this example is the XPath used in the data markings. Becaus
         </stix:Package>
     </stix:Related_Package>
     <stix:Related_Package>
-        <stix:Package id="example:package-162faaf6-4fa8-47d8-b128-115b392bbb19" timestamp="2014-03-26T02:01:00.000000Z" version="1.1">
+        <stix:Package id="example:package-162faaf6-4fa8-47d8-b128-115b392bbb19" version="1.1">
             <stix:STIX_Header>
-                <stix:Title>Indicators for Malware DrownedRat</stix:Title>
-                <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Malware Artifacts</stix:Package_Intent>
+           
                 <stix:Handling>
                     <markings:Marking>
                         <markings:Controlled_Structure>../../../../descendant-or-self::node()</markings:Controlled_Structure>
@@ -94,8 +90,6 @@ from stix.extensions.marking.tlp import TLPMarkingStructure
 
 alpha_package = STIXPackage()
 alpha_package.stix_header = STIXHeader()
-alpha_package.stix_header.title = "Report on Adversary Alpha's Campaign against the Industrial Control Sector"
-rat_package.stix_header.package_intents = "Campaign Characterization"
 alpha_package.stix_header.handling = Marking()
 
 alpha_marking = MarkingSpecification()
@@ -107,16 +101,14 @@ alpha_package.stix_header.handling.add_marking(alpha_marking)
 
 rat_package = STIXPackage()
 rat_package.stix_header = STIXHeader()
-rat_package.stix_header.title = "Indicators for Malware DrownedRat"
-rat_package.stix_header.package_intents = "Indicators - Malware Artifacts"
 rat_package.stix_header.handling = Marking()
 
-bravo_marking = MarkingSpecification()
-bravo_marking.controlled_structure = "../../../../descendant-or-self::node()"
-bravo_tlp_marking = TLPMarkingStructure()
-bravo_tlp_marking.color = "RED"
-alpha_marking.marking_structures.append(bravo_tlp_marking)
-rat_package.stix_header.handling.add_marking(bravo_marking)
+rat_marking = MarkingSpecification()
+rat_marking.controlled_structure = "../../../../descendant-or-self::node()"
+rat_tlp_marking = TLPMarkingStructure()
+rat_tlp_marking.color = "RED"
+alpha_marking.marking_structures.append(rat_tlp_marking)
+rat_package.stix_header.handling.add_marking(rat_marking)
     
 stix_package = STIXPackage()
 info_src = InformationSource()
@@ -124,6 +116,7 @@ info_src.identity = Identity(name="Government Sharing Program - GSP")
 stix_package.stix_header = STIXHeader(information_source=info_src)
 stix_package.related_packages.append(alpha_package)
 stix_package.related_packages.append(rat_package)
+
 
 print stix_package.to_xml()
 {% endhighlight %}

--- a/documentation/idioms/wrapper/plain-wrapper-around-multiple-packages.py
+++ b/documentation/idioms/wrapper/plain-wrapper-around-multiple-packages.py
@@ -14,8 +14,6 @@ from stix.extensions.marking.tlp import TLPMarkingStructure
 def main():
     alpha_package = STIXPackage()
     alpha_package.stix_header = STIXHeader()
-    alpha_package.stix_header.title = "Report on Adversary Alpha's Campaign against the Industrial Control Sector"
-    alpha_package.stix_header.package_intents = "Campaign Characterization"
     alpha_package.stix_header.handling = Marking()
 
     alpha_marking = MarkingSpecification()
@@ -27,8 +25,6 @@ def main():
 
     rat_package = STIXPackage()
     rat_package.stix_header = STIXHeader()
-    rat_package.stix_header.title = "Indicators for Malware DrownedRat"
-    rat_package.stix_header.package_intents = "Indicators - Malware Artifacts"
     rat_package.stix_header.handling = Marking()
 
     rat_marking = MarkingSpecification()

--- a/documentation/idioms/wrapper/plain-wrapper-around-multiple-packages.xml
+++ b/documentation/idioms/wrapper/plain-wrapper-around-multiple-packages.xml
@@ -14,11 +14,9 @@
     http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.1/Address_Object.xsd
     http//data-marking.mitre.org/extensions/MarkingStructure#TLP-1 http://stix.mitre.org/XMLSchema/extensions/marking/tlp/1.1.1/tlp_marking.xsd"
     id="example:package-a7c79e0a-3918-41f0-b7d0-e29df9325aa6"
-    timestamp="2014-05-08T09:00:00.000000Z"
     version="1.1.1"
     >
     <stix:STIX_Header>
-        <stix:Title>Example Plain Wrapper Around Multiple Reports</stix:Title>
         <stix:Information_Source>
             <stixCommon:Identity>
                 <stixCommon:Name>Government Sharing Program - GSP</stixCommon:Name>
@@ -27,10 +25,9 @@
     </stix:STIX_Header>
     <stix:Related_Packages>
         <stix:Related_Package>
-            <stix:Package id="example:package-ca6e215c-fbb7-4b7a-b678-632562f85e93" timestamp="2014-05-08T09:00:00.000000Z" version="1.1.1">
+            <stix:Package id="example:package-ca6e215c-fbb7-4b7a-b678-632562f85e93" version="1.1.1">
                 <stix:STIX_Header>
-                    <stix:Title>Report on Adversary Alpha's Campaign against the Industrial Control Sector</stix:Title>
-                    <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Campaign Characterization</stix:Package_Intent>
+                   
                     <stix:Handling>
                         <markings:Marking>
                             <markings:Controlled_Structure>../../../../descendant-or-self::node()</markings:Controlled_Structure>
@@ -41,10 +38,9 @@
             </stix:Package>
         </stix:Related_Package>
         <stix:Related_Package>
-            <stix:Package id="example:package-162faaf6-4fa8-47d8-b128-115b392bbb19" timestamp="2014-05-08T09:00:00.000000Z" version="1.1.1">
+            <stix:Package id="example:package-162faaf6-4fa8-47d8-b128-115b392bbb19" version="1.1.1">
                 <stix:STIX_Header>
-                    <stix:Title>Indicators for Malware DrownedRat</stix:Title>
-                    <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Malware Artifacts</stix:Package_Intent>
+                   
                     <stix:Handling>
                         <markings:Marking>
                             <markings:Controlled_Structure>../../../../descendant-or-self::node()</markings:Controlled_Structure>

--- a/documentation/idioms/yara-test-mechanism/yara-test-mechanism.xml
+++ b/documentation/idioms/yara-test-mechanism/yara-test-mechanism.xml
@@ -17,7 +17,7 @@
 	http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.1.1/stix_common.xsd
 	http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd
 	http://stix.mitre.org/extensions/TestMechanism#YARA-1 http://stix.mitre.org/XMLSchema/extensions/test_mechanism/yara/1.1.1/yara_test_mechanism.xsd
-	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea99d4d4-1ae7-4120-9ebe-67ed4783fb36" version="1.1.1" timestamp="2014-06-20T15:16:56.986347+00:00">
+	http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.1.1/stix_core.xsd" id="example:Package-ea99d4d4-1ae7-4120-9ebe-67ed4783fb36" version="1.1.1" >
     <stix:Indicators>
         <stix:Indicator id="example:indicator-567b201c-4fd5-4bde-a5db-42abc340807a" timestamp="2014-06-20T15:16:56.987616+00:00" xsi:type='indicator:IndicatorType' negate="false" version="2.1.1">
             <indicator:Title>silent_banker</indicator:Title>


### PR DESCRIPTION
closes #238 

Builds cleanly [using the 1.2 validator](https://travis-ci.org/bschmoker/stixproject.github.io/builds/62124925) as configured in (now rebased out) [travis config](https://github.com/bschmoker/stixproject.github.io/commit/63aea16e5c03774311cbc8486fc5c28f4b7654e0?diff=split)

:exclamation: will fail to build against this branch, since it's not using the same travis config

cc:@stixproject