### PR TITLE
Updated STIX Language version number on homepage to 1.2

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ no_in_page_title: true
   <div class="col-md-4 text-center">
     <h2>Current Release</h2>
     <p>Click for downloads and more.</p>
-    <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.1.1/">STIX Version 1.1.1 »</a></p>
+    <p><a class="btn btn-primary btn-lg" role="button" href="https://stix.mitre.org/language/version1.2/">STIX Version 1.2 »</a></p>
   </div>
   <div class="col-md-4 text-center">
     <h2>Community</h2>


### PR DESCRIPTION
Updated v1.1.1 to v1.2, to be merged after it goes live on stix.mitre.org.