### PR TITLE
Add TAXII to page title so it's STIX/TAXII

### DIFF
--- a/supporters/index.md
+++ b/supporters/index.md
@@ -1,11 +1,11 @@
 ---
 layout: flat
-title: Support for STIX
+title: Support for STIX/TAXII
 ---
 
 `This list is incomplete and actively updated. Inclusion does not represent an endorsement.`
 
-STIX is being implemented in many products, services, and global communities.
+STIX and TAXII are being implemented in many products, services, and global communities.
 
 Please [fill out this form](http://goo.gl/forms/jKQH7a6TfW) to contact the [STIX Team](mailto:stix@mitre.org) and request inclusion or modification under [User Communities](http://stixproject.github.io/supporters/#user-communities) or [Products and Services](http://stixproject.github.io/supporters/#products-and-services). 
 


### PR DESCRIPTION
As I recall it was decided that there would be 3 pages, a combined STIX/TAXII page that would also be linked to from the TAXII github.io site, and then their own individual pages on the CybOX and MAEC and github.io sites?  I am working on the TAXII github.io site updates now, so as part of that I've added TAXII to the title of this page and the intro text.