### PR TITLE
Deleted the Privacy Policy section of the page

### DIFF
--- a/legal/index.md
+++ b/legal/index.md
@@ -6,9 +6,6 @@ title: Legal
 ## License
 STIX is released under a [permissive license for any commercial or non-commercial purpose](http://stix.mitre.org/about/termsofuse.html) while [helper scripts and related tools](https://github.com/STIXProject) have individual licenses that typically follow [Berkeley Software Distribution](http://opensource.org/licenses/BSD-3-Clause). 
 
-## Privacy
-Use of websites and mailing lists is governed by our [privacy policy](http://stix.mitre.org/about/privacy_policy.html)
-
 ## Sample Reports
 - [APT1: Exposing One of China's Cyber Espionage Units (the "APT1 Report")](http://intelreport.mandiant.com/)
 is copyright 2013 by Mandiant Corporation and can be downloaded at 


### PR DESCRIPTION
The Privacy Policy section of the License page was specific to the MITRE websites and discussion lists, so I removed it from the License page.