### PR TITLE
Update the idioms pages to update mitre.org links to their correct urls

### DIFF
--- a/documentation/idioms/cve/index.md
+++ b/documentation/idioms/cve/index.md
@@ -6,11 +6,11 @@ constructs:
 summary: This idiom describes how to represent a disclosed vulnerability identified by a CVE using the Exploit Target construct.
 ---
 
-Threat intelligence often contains references to the vulnerabilities that threat actors are targeting. When those vulnerabilities have been formally disclosed and identified (i.e. are not 0-day or unknown vulnerabilites) they are almost always identified via a [CVE](http://cve.mitre.org) identifier. This idiom describes how to use the STIX Exploit Target element to represent a disclosed vulnerability via its CVE ID.
+Threat intelligence often contains references to the vulnerabilities that threat actors are targeting. When those vulnerabilities have been formally disclosed and identified (i.e., are not 0-day or unknown vulnerabilites) they are almost always identified via a [Common Vulnerabilities and Exposures (CVE®)](http://cve.mitre.org) identifier. This idiom describes how to use the STIX Exploit Target element to represent a disclosed vulnerability via its CVE ID.
 
 ## Scenario
 
-In this scenario, we'll describe [CVE 2013-3893](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-3893) using the STIX exploit target element.
+In this scenario, we'll describe [CVE-2013-3893](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-3893) using the STIX exploit target element.
 
 ## Data model
 
@@ -20,7 +20,7 @@ The relevant STIX component, [Exploit Target](/data-model/{{site.current_version
 
 As you can see, this is a very simple idiom to represent. The `Title` field simply gives the exploit target a human-readable title. Similarly, `Description` and `Short Description` could be used to give it longer human-readable descriptions if desired.
 
-The `Vulnerability` field is used to represent the vulnerability itself. This field is implemented via [VulnerabilityType](/data-model/{{site.current_version}}/et/VulnerabilityType), which can be used to identify vulnerabilities via a CVE ID (as here), OSVDB ID, or even use [CVRF](http://www.icasi.org/cvrf-1.1) to characterize an undisclosed vulnerability.
+The `Vulnerability` field is used to represent the vulnerability itself. This field is implemented via [VulnerabilityType](/data-model/{{site.current_version}}/et/VulnerabilityType), which can be used to identify vulnerabilities via a CVE ID (as here), OSVDB ID, or even use [Common Vulnerability Reporting Framework (CVRF)](http://www.icasi.org/cvrf-1.1) to characterize an undisclosed vulnerability.
 
 Representing the CVE ID is as easy as filling out the `CVE ID` field with a property-formatted CVE identifier.
 

--- a/documentation/idioms/maec-malware/index.md
+++ b/documentation/idioms/maec-malware/index.md
@@ -5,12 +5,12 @@ use_cases:
   - Malware
 constructs:
   - TTP
-summary: In addition to just naming a malware variety, it's occasionally useful to describe that malware's detailed behavior in a structured format. MAEC is a structured language for representing malware behavior and can be used within the STIX TTP construct to describe a detailed characterization of the malware for use in the broader context of campaigns, threat actors, indicators, incidents and exploit targets. This idiom describes the use of the TTP structure to carry a MAEC malware characterization and can serve as a building block to creating related TTPs in the use cases mentioned previously.
+summary: In addition to just naming a malware variety, it's occasionally useful to describe that malware's detailed behavior in a structured format. [Malware Attribute Enumeration and Characterization (MAEC)](https://maecproject.github.io/) is a structured language for representing malware behavior and can be used within the STIX TTP construct to describe a detailed characterization of the malware for use in the broader context of campaigns, threat actors, indicators, incidents and exploit targets. This idiom describes the use of the TTP structure to carry a MAEC malware characterization and can serve as a building block to creating related TTPs in the use cases mentioned previously.
 ---
 
 <img src="/images/Malware.png" class="component-img" alt="Malware Icon" />
 
-Analyzing malware behavior is an important part of any threat intelligence organization's job. The results of this analysis whether from automated tools (static or dynamic) or from manual human analysis can be captured into a structured format called [MAEC](http://maec.mitre.org). MAEC (Malware Attribute Enumeration and Characterization) is a language similar to STIX that is used to describe malware behavior from the very low technical level up to the more abstract contextual levels of behaviors and capabilities. When representing threat intelligence in STIX, it can occasionally be useful to include a full representation of the malware behavior using MAEC in order to share it with other parties or relate its behavior to other pieces of intelligence in STIX.
+Analyzing malware behavior is an important part of any threat intelligence organization's job. The results of this analysis whether from automated tools (static or dynamic) or from manual human analysis can be captured into a structured format called [MAEC](https://maecproject.github.io/). MAEC is a language similar to STIX that is used to describe malware behavior from the very low technical level up to the more abstract contextual levels of behaviors and capabilities. When representing threat intelligence in STIX, it can occasionally be useful to include a full representation of the malware behavior using MAEC in order to share it with other parties or relate its behavior to other pieces of intelligence in STIX.
 
 For more information, see the whitepaper the STIX and MAEC teams developed on [characterizing malware across MAEC and STIX](/about/Characterizing_Malware_MAEC_and_STIX_v1.0.pdf).
 
@@ -71,7 +71,7 @@ for tactic in pkg.ttps:
 
 ## Further Reading
 
-* [MAEC](http://maec.mitre.org)
+* [MAEC](https://maecproject.github.io/)
 * [TTP Component](/data-model/{{site.current_version}}/ttp/TTPType)
 * [MalwareInstanceType](/data-model/{{site.current_version}}/ttp/MalwareInstanceType)
 


### PR DESCRIPTION
Updated links from mitre.org to their correct urls, plus made some other minor copy edits, to the following 4 pages:

http://stixproject.github.io/documentation/idioms/maec-malware/
http://stixproject.github.io/documentation/idioms/cve/
http://stixproject.github.io/documentation/idioms/openioc-test-mechanism/
http://stixproject.github.io/documentation/idioms/leveraged-ttp/