### PR TITLE
Ensured idiom code runs in Python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - sudo apt-get install libxml2-dev libxslt-dev zlib1g-dev
   - pip install stix
   - pip install stix-validator --pre
+  - pip install lxml
   - pip install pep8
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install libxml2-dev libxslt-dev zlib1g-dev
   - pip install stix
-  - pip install stix-validator==2.5.0.dev0
+  - pip install stix-validator --pre
   - pip install pep8
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+  - "2.7"
+  - "3.5"
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install libxml2-dev libxslt-dev zlib1g-dev
   - pip install stix
-  - pip install stix-validator==2.5.0.dev1
+  - pip install stix-validator==2.5.0.dev0
   - pip install pep8
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install libxml2-dev libxslt-dev zlib1g-dev
   - pip install stix
-  - pip install stix-validator
+  - pip install stix-validator==2.5.0.dev1
   - pip install pep8
 
 script: 

--- a/documentation/idioms/affected-assets/incident-with-affected-asset_consumer.py
+++ b/documentation/idioms/affected-assets/incident-with-affected-asset_consumer.py
@@ -3,6 +3,7 @@
 # See LICENSE.txt for complete terms.
 
 import sys
+import io
 from stix.core import STIXPackage
 
 
@@ -35,7 +36,7 @@ if __name__ == '__main__':
         fname = sys.argv[1]
     except:
         exit(1)
-    fd = open(fname)
+    fd = io.open(fname)
     stix_pkg = STIXPackage.from_xml(fd)
 
     parse_stix(stix_pkg)

--- a/documentation/idioms/affected-assets/incident-with-affected-asset_consumer.py
+++ b/documentation/idioms/affected-assets/incident-with-affected-asset_consumer.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
         fname = sys.argv[1]
     except:
         exit(1)
-    fd = io.open(fname)
+    fd = open(fname)
     stix_pkg = STIXPackage.from_xml(fd)
 
     parse_stix(stix_pkg)

--- a/documentation/idioms/affected-assets/incident-with-affected-asset_producer.py
+++ b/documentation/idioms/affected-assets/incident-with-affected-asset_producer.py
@@ -40,7 +40,7 @@ def main():
 
     pkg.add_incident(incident)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/affected-assets/index.md
+++ b/documentation/idioms/affected-assets/index.md
@@ -86,7 +86,7 @@ affected_assets.append(affected_asset)
 incident = Incident(title="Exfiltration from hr-data1.example.com")
 incident.affected_assets = affected_assets
 
-print incident.to_xml()
+print incident.to_xml(encoding=None)
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== INCIDENT Assets Impacted ==")
 for inc in pkg.incidents:

--- a/documentation/idioms/block-network-traffic/block-network-traffic_producer.py
+++ b/documentation/idioms/block-network-traffic/block-network-traffic_producer.py
@@ -36,7 +36,7 @@ def main():
 
     pkg.add_course_of_action(coa)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/block-network-traffic/index.md
+++ b/documentation/idioms/block-network-traffic/index.md
@@ -88,7 +88,7 @@ coa.parameter_observables=Observables(addr)
 
 pkg.add_course_of_action(coa)
 
-print pkg.to_xml()
+print pkg.to_xml(encoding=None)
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== COA ==")
 for coa in pkg.courses_of_action:

--- a/documentation/idioms/c2-indicator/index.md
+++ b/documentation/idioms/c2-indicator/index.md
@@ -67,7 +67,7 @@ indicator.add_indicated_ttp(TTP(idref=ttp.id_))
 stix_package.add_indicator(indicator)
 stix_package.add_ttp(ttp)
 
-print stix_package.to_xml()
+print stix_package.to_xml(encoding=None)
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 stix_package = STIXPackage.from_xml('indicator-for-c2-ip-address.xml')

--- a/documentation/idioms/c2-indicator/indicator-for-c2-ip-address_producer.py
+++ b/documentation/idioms/c2-indicator/indicator-for-c2-ip-address_producer.py
@@ -23,7 +23,7 @@ def main():
     stix_package.add_indicator(indicator)
     stix_package.add_ttp(ttp)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/c2-ip-list/command-and-control-ip-list_producer.py
+++ b/documentation/idioms/c2-ip-list/command-and-control-ip-list_producer.py
@@ -52,7 +52,7 @@ def main():
     ttp.resources = resource
 
     stix_package.add_ttp(ttp)
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/c2-ip-list/index.md
+++ b/documentation/idioms/c2-ip-list/index.md
@@ -105,7 +105,7 @@ ttp = TTP(title="Malware C2 Channel")
 ttp.resources = resource
 
 stix_package.add_ttp(ttp)
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 print("== TTP ==")

--- a/documentation/idioms/campaign-v-actors/campaign-v-actors_producer.py
+++ b/documentation/idioms/campaign-v-actors/campaign-v-actors_producer.py
@@ -38,7 +38,7 @@ def main():
     pkg = STIXPackage()
     pkg.add_campaign(c)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/campaign-v-actors/index.md
+++ b/documentation/idioms/campaign-v-actors/index.md
@@ -93,7 +93,7 @@ c.related_incidents.append(Incident(idref="example:incident-7d8cf96f-91cb-42d0-a
 pkg = STIXPackage()
 pkg.add_campaign(c)
 
-print(pkg.to_xml())
+print(pkg.to_xml(encoding=None))
 
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}

--- a/documentation/idioms/cve/cve-in-exploit-target_producer.py
+++ b/documentation/idioms/cve/cve-in-exploit-target_producer.py
@@ -22,7 +22,7 @@ def main():
 
     pkg.add_exploit_target(et)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/cve/index.md
+++ b/documentation/idioms/cve/index.md
@@ -48,7 +48,7 @@ vuln.add_reference("https://technet.microsoft.com/library/security/2887505")
 et = ExploitTarget(title="Javascript vulnerability in MSIE 6-11")
 et.add_vulnerability(vuln)
     
-print et.to_xml()
+print et.to_xml(encoding=None)
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== VULNERABILITY ==")
 for target in pkg.exploit_targets:

--- a/documentation/idioms/file-hash-reputation/file-hash-reputation_producer.py
+++ b/documentation/idioms/file-hash-reputation/file-hash-reputation_producer.py
@@ -34,7 +34,7 @@ def main():
 
     stix_package.add_indicator(indicator)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/identity-group/identifying-a-threat-actor-group_producer.py
+++ b/documentation/idioms/identity-group/identifying-a-threat-actor-group_producer.py
@@ -39,7 +39,7 @@ def main():
 
     ta.identity.specification = identity_spec
     stix_package.add_threat_actor(ta)
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/identity-group/index.md
+++ b/documentation/idioms/identity-group/index.md
@@ -88,7 +88,7 @@ identity_spec.add_electronic_address_identifier("twitter.com/realdiscoteam")
     
 ta.identity.specification = identity_spec
 stix_package.add_threat_actor(ta)
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print "== ACTOR =="

--- a/documentation/idioms/incident-malware/incident-malware_producer.py
+++ b/documentation/idioms/incident-malware/incident-malware_producer.py
@@ -31,7 +31,7 @@ def main():
     stix_package.add_ttp(ttp)
     stix_package.add_incident(incident)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/incident-malware/index.md
+++ b/documentation/idioms/incident-malware/index.md
@@ -78,7 +78,7 @@ stix_package = STIXPackage()
 stix_package.add_ttp(ttp)
 stix_package.add_incident(incident)
 
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== TTP ==")

--- a/documentation/idioms/incident-vs-indicator/combined-producer.py
+++ b/documentation/idioms/incident-vs-indicator/combined-producer.py
@@ -60,7 +60,7 @@ def main():
 
         stix_package.add_incident(incident)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/incident-vs-indicator/incident-producer.py
+++ b/documentation/idioms/incident-vs-indicator/incident-producer.py
@@ -45,7 +45,7 @@ def main():
 
         stix_package.add_incident(incident)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/incident-vs-indicator/indicator-producer.py
+++ b/documentation/idioms/incident-vs-indicator/indicator-producer.py
@@ -38,7 +38,7 @@ def main():
 
         stix_package.add_indicator(indicator)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/indicator-w-kill-chain/index.md
+++ b/documentation/idioms/indicator-w-kill-chain/index.md
@@ -64,7 +64,7 @@ stix_pkg.add_indicator(ind)
 # add referenced phase to indicator
 ind.kill_chain_phases.append(KillChainPhaseReference(phase_id=infect.phase_id,kill_chain_id = mychain.id_))
 
-print(stix_pkg.to_xml())
+print(stix_pkg.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 

--- a/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain_producer.py
+++ b/documentation/idioms/indicator-w-kill-chain/indicator-w-kill-chain_producer.py
@@ -28,7 +28,7 @@ def main():
     # add referenced phase to indicator
     ind.kill_chain_phases.append(KillChainPhaseReference(phase_id=infect.phase_id, kill_chain_id=mychain.id_))
 
-    print(stix_pkg.to_xml())
+    print(stix_pkg.to_xml(encoding=None))
 
 if __name__ == "__main__":
     main()

--- a/documentation/idioms/indicators-to-campaigns/new-style-producer.py
+++ b/documentation/idioms/indicators-to-campaigns/new-style-producer.py
@@ -24,7 +24,7 @@ def main():
     # TODO: Broken, see #192
     # indicator.related_campaigns.append(RelatedCampaign(item=Campaign(idref=campaign.id_)))
 
-    print(package.to_xml())
+    print(package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/indicators-to-campaigns/old-style-producer.py
+++ b/documentation/idioms/indicators-to-campaigns/old-style-producer.py
@@ -23,7 +23,7 @@ def main():
     # Link the campaign to the indicator
     campaign.related_indicators.append(RelatedIndicator(item=Indicator(idref=indicator.id_)))
 
-    print(package.to_xml())
+    print(package.to_xml(encoding=None))
 
 
 if __name__ == '__main__':

--- a/documentation/idioms/industry-sector/index.md
+++ b/documentation/idioms/industry-sector/index.md
@@ -54,7 +54,7 @@ ttp = TTP(title="Victim Targeting: Electricity Sector and Industrial Control Sys
 ttp.victim_targeting = VictimTargeting()
 ttp.victim_targeting.identity = ciq_identity
 
-print(ttp.to_xml())
+print(ttp.to_xml(encoding=None))
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 print("== TTP ==")

--- a/documentation/idioms/industry-sector/victim-targeting-sector_producer.py
+++ b/documentation/idioms/industry-sector/victim-targeting-sector_producer.py
@@ -23,7 +23,7 @@ def main():
     stix_package = STIXPackage()
     stix_package.add_ttp(ttp)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/kill-chain/index.md
+++ b/documentation/idioms/kill-chain/index.md
@@ -90,7 +90,7 @@ indicator.kill_chain_phases = KillChainPhasesReference([
 ])
 stix_pkg.add_indicator(indicator)
 
-print(stix_pkg.to_xml())
+print(stix_pkg.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 kill_chains = {}

--- a/documentation/idioms/kill-chain/kill-chain_producer.py
+++ b/documentation/idioms/kill-chain/kill-chain_producer.py
@@ -44,7 +44,7 @@ def main():
     ])
     stix_pkg.add_indicator(indicator)
 
-    print(stix_pkg.to_xml())
+    print(stix_pkg.to_xml(encoding=None))
 
 if __name__ == "__main__":
     main()

--- a/documentation/idioms/leveraged-ttp/index.md
+++ b/documentation/idioms/leveraged-ttp/index.md
@@ -112,7 +112,7 @@ stix_package.add_ttp(ttp_phishing)
 stix_package.add_ttp(ttp_pivy)
 stix_package.add_threat_actor(ta_bravo)
 
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}

--- a/documentation/idioms/leveraged-ttp/threat-actor-leveraging-attack-patterns-and-malware_producer.py
+++ b/documentation/idioms/leveraged-ttp/threat-actor-leveraging-attack-patterns-and-malware_producer.py
@@ -47,7 +47,7 @@ def main():
     stix_package.add_ttp(ttp_pivy)
     stix_package.add_threat_actor(ta_bravo)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/maec-malware/index.md
+++ b/documentation/idioms/maec-malware/index.md
@@ -54,7 +54,7 @@ ttp = TTP(title="Poison Ivy Variant v4392-acc")
 ttp.behavior = Behavior()
 ttp.behavior.add_malware_instance(maec_malware_instance)
 
-print(ttp.to_xml())
+print(ttp.to_xml(encoding=None))
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== TTP ==")
 for tactic in pkg.ttps:

--- a/documentation/idioms/maec-malware/malware-characterization-using-maec_producer.py
+++ b/documentation/idioms/maec-malware/malware-characterization-using-maec_producer.py
@@ -839,7 +839,7 @@ def main():
     stix_package = STIXPackage()
     stix_package.add_ttp(ttp)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/malicious-email-attachment/index.md
+++ b/documentation/idioms/malicious-email-attachment/index.md
@@ -194,7 +194,7 @@ combined_indicator.add_indicated_ttp(TTP(idref=ttp.id_))
 stix_package.add_indicator(combined_indicator)
 stix_package.add_indicator(email_subject_indicator)
 stix_package.add_indicator(indicator_attachment)
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 

--- a/documentation/idioms/malicious-email-attachment/malicious-email-indicator-with-attachment_producer.py
+++ b/documentation/idioms/malicious-email-attachment/malicious-email-indicator-with-attachment_producer.py
@@ -75,7 +75,7 @@ def main():
     stix_package.add_indicator(combined_indicator)
     stix_package.add_indicator(email_subject_indicator)
     stix_package.add_indicator(indicator_attachment)
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/malicious-url/index.md
+++ b/documentation/idioms/malicious-url/index.md
@@ -50,7 +50,7 @@ url.type_ =  URI.TYPE_URL
 url.condition = "Equals"
 
 indicator.add_observable(url)
-print(indicator.to_xml())
+print(indicator.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 

--- a/documentation/idioms/malicious-url/indicator-for-malicious-url_producer.py
+++ b/documentation/idioms/malicious-url/indicator-for-malicious-url_producer.py
@@ -23,7 +23,7 @@ def main():
 
     pkg.add_indicator(indicator)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/malware-hash/index.md
+++ b/documentation/idioms/malware-hash/index.md
@@ -89,7 +89,7 @@ indicator.add_indicated_ttp(TTP(idref=ttp.id_))
 stix_package.add_indicator(indicator)
 stix_package.add_ttp(ttp)
     
-print(stix_package.to_xml())
+print(stix_package.to_xml(encoding=None))
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 
 print("== MALWARE ==")

--- a/documentation/idioms/malware-hash/malware-indicator-for-file-hash_producer.py
+++ b/documentation/idioms/malware-hash/malware-indicator-for-file-hash_producer.py
@@ -38,7 +38,7 @@ def main():
     stix_package.add_indicator(indicator)
     stix_package.add_ttp(ttp)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/openioc-test-mechanism/openioc-test-mechanism-producer.py
+++ b/documentation/idioms/openioc-test-mechanism/openioc-test-mechanism-producer.py
@@ -46,7 +46,7 @@ def main():
     stix_package.add_indicator(indicator)
     stix_package.add_ttp(ttp)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/related-observables/incident-with-related-observables_producer.py
+++ b/documentation/idioms/related-observables/incident-with-related-observables_producer.py
@@ -38,7 +38,7 @@ def main():
 
     pkg.add_incident(incident)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/related-observables/index.md
+++ b/documentation/idioms/related-observables/index.md
@@ -101,7 +101,7 @@ related_observable2 = RelatedObservable(observable2, relationship="Malicious Art
 incident.related_observables.append(related_observable1)
 incident.related_observables.append(related_observable2)
 
-print(incident.to_xml())
+print(incident.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 print("== INCIDENT ==")

--- a/documentation/idioms/simple-incident/simple-incident_producer.py
+++ b/documentation/idioms/simple-incident/simple-incident_producer.py
@@ -61,4 +61,4 @@ def build_stix():
 if __name__ == '__main__':
     # emit STIX
     pkg = build_stix()
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))

--- a/documentation/idioms/snort-test-mechanism/snort-test-mechanism-producer.py
+++ b/documentation/idioms/snort-test-mechanism/snort-test-mechanism-producer.py
@@ -52,7 +52,7 @@ def main():
 
     stix_package.add_indicator(indicator)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/victim-targeting/index.md
+++ b/documentation/idioms/victim-targeting/index.md
@@ -67,7 +67,7 @@ pkg = STIXPackage()
 pkg.add_campaign(c)
 pkg.add_ttp(ttp)
 
-print(pkg.to_xml())
+print(pkg.to_xml(encoding=None))
 
 {% endhighlight %}{% include tab_separator.html %}{% highlight python linenos %}
 

--- a/documentation/idioms/victim-targeting/victim-targeting_producer.py
+++ b/documentation/idioms/victim-targeting/victim-targeting_producer.py
@@ -33,7 +33,7 @@ def main():
     pkg.add_campaign(c)
     pkg.add_ttp(ttp)
 
-    print(pkg.to_xml())
+    print(pkg.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/documentation/idioms/yara-test-mechanism/yara-test-mechanism-producer.py
+++ b/documentation/idioms/yara-test-mechanism/yara-test-mechanism-producer.py
@@ -46,7 +46,7 @@ rule silent_banker : banker
 
     stix_package.add_indicator(indicator)
 
-    print(stix_package.to_xml())
+    print(stix_package.to_xml(encoding=None))
 
 if __name__ == '__main__':
     main()

--- a/test_idioms.sh
+++ b/test_idioms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${VERBOSE:=1}
+: ${VERBOSE:=0}
 
 # Validate that VERBOSE is an integer to prevent
 # code injection exploits.

--- a/test_idioms.sh
+++ b/test_idioms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${VERBOSE:=0}
+: ${VERBOSE:=1}
 
 # Validate that VERBOSE is an integer to prevent
 # code injection exploits.


### PR DESCRIPTION
Altered .travis.yml to run using Python 2.7 and 3.5 and idiom producer scripts to prevent Python 3.5 build from failing.