### PR TITLE
Update index page to more clearly emphasize archive status

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: flat
-title: STIX - Structured Threat Information Expression
+title: STIX - Structured Threat Information Expression (Archive)
 tagline: A structured language for cyber threat intelligence information
 no_in_page_title: true
 ---
@@ -8,8 +8,10 @@ no_in_page_title: true
 
 
 <div class="jumbotron">
-  <h1>Structured Threat Information eXpression (STIX™)</h1>
+  <h3>Structured Threat Information eXpression (STIX™) 1.x Archive Website</h3>
   <p>A structured language for cyber threat intelligence.</p>
+  <p></p>
+  <h4>Go to the <a href="https://oasis-open.github.io/cti-documentation/">STIX 2.0 website</a>.</h4>
   <br />
   <div class="row">
     <div class="col-md-6 text-center">


### PR DESCRIPTION
@johnwunder I made some minor edits to the main landing page to make it extremely obvious right in the page title and main section of the landing page that this is the archive website and they need to go elsewhere for current 2.0 website. Okay to do a pull request? 

Also, should we remove the sentence at the bottom of the page directing them to the Blog since we are no longer using it?