### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,10 +8,10 @@ no_in_page_title: true
 
 
 <div class="jumbotron">
-  <h3>Structured Threat Information eXpression (STIX™) 1.x Archive Website</h3>
-  <p>A structured language for cyber threat intelligence.</p>
+  <h2>Structured Threat Information eXpression (STIX™) 1.x Archive Website</h2>
+  <p>A structured language for cyber threat intelligence</p>
   <p></p>
-  <h4>Go to the <a href="https://oasis-open.github.io/cti-documentation/">STIX 2.0 website</a>.</h4>
+  <h3>Go to the <a href="https://oasis-open.github.io/cti-documentation/">STIX 2.0 documentation website</a>.</h3>
   <br />
   <div class="row">
     <div class="col-md-6 text-center">


### PR DESCRIPTION
Made some minor edits to the main landing page to make it extremely obvious right in the page title and main section of the landing page that this is the archive website and they need to go elsewhere for current 2.0 documentation website. 