### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ no_in_page_title: true
 
 
 <div class="jumbotron">
-  <h2>Structured Threat Information eXpression (STIX™) 1.x Archive Website</h2>
+  <h1>Structured Threat Information eXpression (STIX™) 1.x Archive Website</h1>
   <p>A structured language for cyber threat intelligence</p>
   <p></p>
   <h3>Go to the <a href="https://oasis-open.github.io/cti-documentation/">STIX 2.0 documentation website</a>.</h3>


### PR DESCRIPTION
Made some minor edits to the main landing page to make it extremely obvious right in the page title and main section of the landing page that this is the archive website and they need to go elsewhere for current 2.0 documentation website. 